### PR TITLE
update: fix fwupdate call

### DIFF
--- a/admin/update
+++ b/admin/update
@@ -34,4 +34,4 @@ done
 CMD="fwupdate"
 [[ -z "${YES}" ]] || CMD+=" --yes"
 [[ -z "${CLEAR}" ]] || CMD+=" --reset"
-exec ${CMD} "${FILE}"
+exec ${CMD} -f "${FILE}"


### PR DESCRIPTION
fwupdate requires the `-f` key to specify a bundle path.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>