### PR TITLE
vegman: sensors: use lssensors

### DIFF
--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -15,7 +15,7 @@ function cmd_inventory {
 # @doc cmd_sensors
 # Sensor readings
 function cmd_sensors {
-  ipmitool sensor list
+  lssensors "$@"
 }
 
 # @doc cmd_logs


### PR DESCRIPTION
This replaces `ipmitool sensor` with `lssensors` in `health` for Vegman.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>