### PR TITLE
bmc/datetime/ntpconfig: add interface support

### DIFF
--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -180,7 +180,7 @@ function cmd_datetime_ntpconfig {
   if [[ $# -ne 2 ]]; then
     abort_badarg "Expected exactly 2 arguments"
   fi
-  netconfig ntp "$1" "$2"
+  netconfig ntp "eth0" "$1" "$2"
 }
 
 # @sudo cmd_ifconfig admin

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -175,12 +175,12 @@ function cmd_datetime_show {
 # @sudo cmd_datetime_ntpconfig admin
 # @doc cmd_datetime_ntpconfig
 # Configure NTP server connection
-#  {add|del} IP
+#  {interface} {add|del} IP
 function cmd_datetime_ntpconfig {
-  if [[ $# -ne 2 ]]; then
-    abort_badarg "Expected exactly 2 arguments"
+  if [[ $# -ne 3 ]]; then
+    abort_badarg "Expected exactly 3 arguments"
   fi
-  netconfig ntp "$1" "$2"
+  netconfig ntp "$1" "$2" "$3"
 }
 
 # @sudo cmd_ifconfig admin


### PR DESCRIPTION
`netconfig` now expects the interface name for commands to add and
remove DNS and NTP servers.

This commit brings:
 - The hardcoded interface name for NICOLE and VESNIN as they have only
   one.
 - The change of `ntpconfig` signature for VEGMAN to make interface
   name a required argument.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>