### PR TITLE
vegman: Support virtual media and NBD client

### DIFF
--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -353,3 +353,88 @@ function cmd_reboot {
   echo "Reboot the BMC..."
   reboot ${force}
 }
+
+# @doc cmd_remoteimage
+# Access to the remote side file
+function cmd_remoteimage {
+  subcommand "$@"
+}
+
+# @sudo cmd_remoteimage_connect admin
+# @doc cmd_remoteimage_connect
+# Connect to the remote server via the specified protocol
+#   --nbd <0..10>     use NBD protocol to connect the remote server with specified NBD device number
+#   address[:port]    remote server address
+function cmd_remoteimage_connect {
+    local nbd_device=""
+    local remote_point=""
+    local address=""
+    local port=""
+
+    while [[ $# -gt 0 ]]; do
+      case "${1}" in
+        --nbd)
+          if [[ $# -lt 2 ]]; then
+            echo "The NBD device number shall be specified" >&2
+            return 1
+          fi
+          nbd_device="/dev/nbd${2}"
+          shift
+          ;;
+        *)
+          if [[ -n "${remote_point}" ]]; then
+            abort_badarg "${1}"
+          else
+            remote_point="${1}"
+          fi
+          address="${remote_point%:*}"
+          port="${remote_point#*:}"
+          ;;
+      esac
+      shift
+    done
+
+    if [[ -z "${port}" ]]; then
+        port=10809
+    fi
+
+    if [[ -z "${address}" ]] || [[ -z "${port}" ]]; then
+      echo "The remote server address shall be specified." >&2
+      return 1
+    fi
+
+    echo "Connecting to NBD server ${remote_point}..."
+    nbd-client "${address}" "${port}" "${nbd_device}"
+}
+
+# @sudo cmd_remoteimage_disconnect admin
+# @doc cmd_remoteimage_disconnect
+# Dissconnect NBD session
+#   -y, --yes       do not ask for confirmation
+#   --nbd <0..10>   the number of NBD device
+function cmd_remoteimage_disconnect {
+  local yes=""
+  local nbd_device=""
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -y | --yes) yes="y";;
+      --nbd)
+        if [[ $# -lt 2 ]] || [[ ${2:0:1} == "-" ]]; then
+          echo "The NBD device number shall be specified" >&2
+          return 1
+        fi
+        nbd_device="/dev/nbd${2}"
+        shift
+        ;;
+      *) abort_badarg "${1}";;
+    esac
+    shift
+  done
+
+  if [[ -z "${yes}" ]]; then
+    confirm
+  fi
+
+  nbd-client -d "${nbd_device}"
+}

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -63,6 +63,71 @@ function cmd_power_status {
   ipmitool power status
 }
 
+# @doc cmd_virtualmedia
+# Access Virtual Media
+function cmd_virtualmedia {
+  subcommand "$@"
+}
+
+# @sudo cmd_virtualmedia_mount admin
+# @doc cmd_virtualmedia_mount
+# Mount a virtual media
+#  --usb    - the USB interface type
+#  --usb-ro - the USB interface type (read-only)
+#  --hdd    - the HDD interface type
+#  --cdrom  - the CD/DVD/BD-ROM interface type (read-only), based on file size
+#  FILE — path to image file
+function cmd_virtualmedia_mount {
+  local imagefile=""
+  local type=""
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      --usb) type="usb";;
+      --usb-ro) type="usb-ro";;
+      --hdd) type="hdd";;
+      --cdrom) type="cdrom";;
+      *)
+        if [[ -n "${imagefile}" ]]; then
+          abort_badarg "${1}"
+        else
+          imagefile="${1}"
+        fi
+        ;;
+    esac
+    shift
+  done
+
+  if [[ ! -e ${imagefile} ]] || [[ -d ${imagefile} ]]; then
+    echo "Please specify the path to image file" >&2
+    return 1
+  fi
+
+  usb-ctrl insert "usb.ms.cli" "${imagefile}" "${type}"
+}
+
+# @sudo cmd_virtualmedia_umount admin
+# @doc cmd_virtualmedia_umount
+# Unmount the virtual media
+#  -y, --yes  - does not ask for interactive confirmation
+function cmd_virtualmedia_umount {
+  local yes=""
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -y | --yes) yes="y";;
+      *) abort_badarg "${1}";;
+    esac
+    shift
+  done
+
+  if [[ -z "${yes}" ]]; then
+    confirm
+  fi
+
+  usb-ctrl eject "usb.ms.cli"
+}
+
 # @doc cmd_console
 # Open virtual console
 function cmd_console {


### PR DESCRIPTION
Adds support bellow commands:

```bash
# host virtualmedia mount (--usb,--usb-ro,--hdd,--cdrom) </file/path>
# host virtualmedia umount [-y,--yes]
# bmc remoteimage connect (--nbd NUMBER) address[:port]
# bmc remoteimage disconnect [-y,--yes] --nbd NUMBER
```
    
This command set uses to allow access to VM functions for admin.