### PR TITLE
remotemedia: Add the NBD export name flag

### DIFF
--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -363,22 +363,32 @@ function cmd_remoteimage {
 # @sudo cmd_remoteimage_connect admin
 # @doc cmd_remoteimage_connect
 # Connect to the remote server via the specified protocol
-#   --nbd <0..10>     use NBD protocol to connect the remote server with specified NBD device number
-#   address[:port]    remote server address
+#   --nbd <0..10>         use NBD protocol to connect the remote server with specified NBD device number
+#   -e,--export <name>    the name of the export
+#   address[:port]        remote server address
 function cmd_remoteimage_connect {
     local nbd_device=""
     local remote_point=""
     local address=""
     local port=""
+    local export_name=""
 
     while [[ $# -gt 0 ]]; do
       case "${1}" in
         --nbd)
           if [[ $# -lt 2 ]]; then
-            echo "The NBD device number shall be specified" >&2
+            echo "The ordinal number of the NBD device is required." >&2
             return 1
           fi
           nbd_device="/dev/nbd${2}"
+          shift
+          ;;
+        -e | --export)
+          if [[ $# -lt 2 ]]; then
+            echo "The export name of the NBD device is required" >&2
+            return 1
+          fi
+          export_name="--name ${2} "
           shift
           ;;
         *)
@@ -394,6 +404,11 @@ function cmd_remoteimage_connect {
       shift
     done
 
+    if [[ -z "${nbd_device}" ]]; then
+      echo "The NBD device number shall be specified." >&2
+      return 1
+    fi
+
     if [[ -z "${port}" ]]; then
         port=10809
     fi
@@ -404,12 +419,12 @@ function cmd_remoteimage_connect {
     fi
 
     echo "Connecting to NBD server ${remote_point}..."
-    nbd-client "${address}" "${port}" "${nbd_device}"
+    nbd-client ${export_name} "${address}" "${port}" "${nbd_device}"
 }
 
 # @sudo cmd_remoteimage_disconnect admin
 # @doc cmd_remoteimage_disconnect
-# Dissconnect NBD session
+# Disconnect NBD session
 #   -y, --yes       do not ask for confirmation
 #   --nbd <0..10>   the number of NBD device
 function cmd_remoteimage_disconnect {
@@ -431,6 +446,11 @@ function cmd_remoteimage_disconnect {
     esac
     shift
   done
+
+  if [[ -z "${nbd_device}" ]]; then
+    echo "The NBD device number shall be specified." >&2
+    return 1
+  fi
 
   if [[ -z "${yes}" ]]; then
     confirm

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -98,6 +98,11 @@ function cmd_virtualmedia_mount {
     shift
   done
 
+ if [[ -z "${type}" ]]; then
+    echo "Please specify the Virtual Media interface type" >&2
+    return 1
+  fi
+
   if [[ ! -e ${imagefile} ]] || [[ -d ${imagefile} ]]; then
     echo "Please specify the path to image file" >&2
     return 1


### PR DESCRIPTION
The many NBD-server implementations require the export name to select
the relevant exporting file.
Additionally, this patch adds a test that the `nbd_number` has been
specified, which there is an important required parameter.

End-user-impact: Now, the `bmc remoteimage` command has a way to specify
                 the NBD exporting name.

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>
Change-Id: I86974aae68b949d025ef874d82a167b96794c714