### PR TITLE
health: logs: Use dreport instead of journalctl

### DIFF
--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -25,17 +25,35 @@ function cmd_logs {
 }
 
 # @doc cmd_logs_list
-# Get list of system logs
-#function cmd_logs_list {
-#  not implemented
-#}
+# Get list of available logs
+function cmd_logs_list {
+    expect_noarg "$@"
+
+    local brief=
+    local name=
+    for entry in /usr/share/dreport.d/pl_user.d/*; do
+        brief="$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})"
+        name="$(realpath ${entry})"
+        printf "%-20s%s\n" "${name##*/}" "${brief}"
+    done
+}
 
 # @sudo cmd_logs_show admin,operator
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
-  expect_noarg "$@"
-  journalctl --no-hostname --no-pager
+  local name="${1:-}"
+  local file="/usr/share/dreport.d/plugins.d/${name}"
+
+  for link in /usr/share/dreport.d/pl_user.d/E*${name}; do
+    if [[ -f "${file}" ]] && [[ "$(realpath ${link})" = "${file}" ]]; then
+      DREPORT_INCLUDE="/usr/share/cli/.include" \
+      TIME_STAMP="$(date -u)" exec "${file}"
+      return 1
+    fi
+  done
+
+  abort_badarg "${name}"
 }
 
 # @sudo cmd_logs_export admin,operator
@@ -43,9 +61,15 @@ function cmd_logs_show {
 # Export system logs
 function cmd_logs_export {
   expect_noarg "$@"
-  local file="/tmp/bmc_$(date +'%Y%m%d_%H%M%S').log"
-  journalctl --no-hostname --no-pager --output verbose > "${file}"
-  echo "Logs are exported to the file ${file}."
+
+  local path="/run/dreport"
+  local prefix="obmcdump_"
+  local ext=".tar.gz"
+  local timestamp="$(date +%Y%m%d%H%M%S)"
+
+  dreport -v -n "${prefix}${timestamp}" -d "${path}"
+
+  echo "Logs are exported to the file '${path}/${prefix}${timestamp}${ext}'"
 }
 
 # @sudo cmd_logs_clear admin

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -24,12 +24,36 @@ function cmd_logs {
   subcommand "$@"
 }
 
+# @doc cmd_logs_list
+# Get list of available logs
+function cmd_logs_list {
+    expect_noarg "$@"
+
+    local brief=
+    local name=
+    for entry in /usr/share/dreport.d/pl_user.d/*; do
+        brief="$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})"
+        name="$(realpath ${entry})"
+        printf "%-20s%s\n" "${name##*/}" "${brief}"
+    done
+}
+
 # @sudo cmd_logs_show admin,operator
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
-  expect_noarg "$@"
-  journalctl --no-hostname --no-pager
+  local name="${1:-}"
+  local file="/usr/share/dreport.d/plugins.d/${name}"
+
+  for link in /usr/share/dreport.d/pl_user.d/E*${name}; do
+    if [[ -f "${file}" ]] && [[ "$(realpath ${link})" = "${file}" ]]; then
+      DREPORT_INCLUDE="/usr/share/cli/.include" \
+      TIME_STAMP="$(date -u)" exec "${file}"
+      return 1
+    fi
+  done
+
+  abort_badarg "${name}"
 }
 
 # @sudo cmd_logs_export admin,operator
@@ -37,9 +61,15 @@ function cmd_logs_show {
 # Export system logs
 function cmd_logs_export {
   expect_noarg "$@"
-  local file="/tmp/bmc_$(date +'%Y%m%d_%H%M%S').log"
-  journalctl --no-hostname --no-pager --output verbose > "${file}"
-  echo "Logs are exported to the file ${file}."
+
+  local path="/run/dreport"
+  local prefix="obmcdump_"
+  local ext=".tar.gz"
+  local timestamp="$(date +%Y%m%d%H%M%S)"
+
+  dreport -v -n "${prefix}${timestamp}" -d "${path}"
+
+  echo "Logs are exported to the file '${path}/${prefix}${timestamp}${ext}'"
 }
 
 # @sudo cmd_logs_clear admin

--- a/functions
+++ b/functions
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# @brief dreport plugins functions.
+#
+# This file is part of the CLI project.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2021 YADRO
+#
+# @author: Alexander Soldatov <a.soldatov@yadro.com>
+# @author: Alexander Filippov <a.filippov@yadro.com>
+
+# @brief output command result to stdout
+# @param command
+function add_cmd_output()
+{
+    eval "${1}" | cat
+}
+
+# @brief output file content to stdout
+# @param file fullname
+function add_copy_file()
+{
+    local file_name="$1"
+    if [[ -f $file_name ]]; then
+      cat "$file_name"
+    elif [[ -d $file_name ]]; then
+      zcat "$file_name"/*.gz
+    else
+      echo "Not a log: ${file_name}"
+    fi
+}
+
+# @brief Copy the symbolic link file to the dreport packaging,
+#        if it is in the user allowed dump size limit.
+# @param $1 symbolic link file name
+# @param $2 Plugin description used for logging.
+function add_copy_sym_link_file()
+{
+    add_copy_file "$(realpath ${1})" "${2}"
+}
+
+# @brief log the error message
+# @param error message
+function log_error()
+{
+   echo "$($TIME_STAMP) ERROR: $@"
+}
+
+# @brief log warning message
+# @param warning message
+function log_warning()
+{
+    if ((verbose == TRUE)); then
+        echo "$($TIME_STAMP) WARNING: $@"
+    fi
+}
+
+# @brief log info message
+# @param info message
+function log_info()
+{
+    if ((verbose == TRUE)); then
+        echo "$($TIME_STAMP) INFO: $@"
+    fi
+}
+
+# @brief log mmary message
+# @param message
+function log_summary()
+{
+    echo "$($TIME_STAMP) $@"
+}
+

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,8 @@ echo "Install Phosphor CLI environment to ${INSTALL_ROOT}"
 
 install -DT --mode 0555 "${THIS_DIR}/clicmd" "${INSTALL_ROOT}/usr/bin/clicmd"
 install -DT --mode 0644 "${THIS_DIR}/profile.in" "${INSTALL_ROOT}${DEFAULT_PROFILE}"
+install -DT --mode 0644 "${THIS_DIR}/functions" \
+    "${INSTALL_ROOT}${SHARE_DIR}/.include/functions"
 
 for SRC_FILE in "${THIS_DIR}/commands"/*; do
   # filter out by target machine


### PR DESCRIPTION
All our platforms have `dreport` from `phosphor-debug-collector` on
board and this tool is more useful for collecting data about the system.

This commit replaces `journalctl` calls with `dreport` ones.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>