### PR TITLE
Feature/restrict help by role

### DIFF
--- a/clicmd
+++ b/clicmd
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 # Base CLI command handler.
 # This script is used for setting up the environment, elevating privileges
 # and handling hierarchical commands.

--- a/clicmd
+++ b/clicmd
@@ -16,6 +16,15 @@ GROUP_ADMIN="%GROUP_ADMIN%"
 GROUP_OPERATOR="%GROUP_OPERATOR%"
 GROUP_USER="%GROUP_USER%"
 
+# If we are running escalated, we have GROUP already set by the caller
+if [[ "${USER}" != "root" || ! -v GROUP ]]; then
+  if [[ "${USER}" = "root" ]]; then
+    echo "Can't run CLI commands as root directly, use an admin account" >&2
+    exit 2
+  fi
+  GROUP=$(id -Gn | sed -n 's/.*\(%GROUP_REGEX%\)[ ]*.*$/\1/gp')
+fi
+
 # Lookup for group by role name (privilege in BMC terms)
 function role_to_group {
   case "$1" in
@@ -42,6 +51,8 @@ function group_to_role {
   esac
 }
 
+ROLE=$(group_to_role ${GROUP})
+
 # command to execute
 USER_CMD="${BASH_SOURCE[0]}"
 REAL_CMD="/usr/share/cli/$(basename "${USER_CMD}")"
@@ -60,8 +71,8 @@ function subcommand {
     print_help "${parent}" | head -n 1
     local cmd
     for cmd in ${children[*]}; do
-      printf "%-16s " "${cmd#${parent}_}"
-      print_help "${cmd}" | head -n 1
+      local help=$(print_help "${cmd}" | head -n 1)
+      [[ -n "${help}" ]] && printf "%-16s %s\n" "${cmd#${parent}_}" "${help}"
     done
     return
   fi
@@ -86,7 +97,7 @@ function subcommand {
   # if command has @sudo tag - we need to run the function with elevated privileges
   if grep -q "^#\\s*@sudo\\s\\+${cmd}\\s" "${REAL_CMD}" && [[ ${EUID} -ne 0 ]]; then
     local sub_path="${cmd/#cmd_}"
-    exec sudo ${USER_CMD} ${sub_path//_/ } "$@"
+    GROUP=${GROUP} exec sudo ${USER_CMD} ${sub_path//_/ } "$@"
   fi
 
   # execute subcommand
@@ -95,7 +106,36 @@ function subcommand {
 
 # Print help for specified command.
 function print_help {
-  sed -n "/^#\\s\\+@doc\\s\\+${1}\\s*$/,/^function/ s/^#\\s*//p" "${REAL_CMD}" | tail -n+2
+  local user_cmd=${1}
+  awk "
+  # Clear match on non-comment lines
+  /^[^#]/ { matched = 0; restricted = 0; next }
+
+  # All comment blocks with @restrict are checked against the current role
+  # and marked as matching if needed
+  /^#\\s+@restrict\\s+${user_cmd}\\s+/ {
+    restricted = 1
+    split(\$4,roles,\",\")
+    for (i = 0; i < length(roles); i++) {
+      if (roles[i] == \"${ROLE}\") {
+        matched = 1
+      }
+    }
+    next
+  }
+
+  # Any comment line after @doc for the command must be printed
+  # if there was no @restrict in this comment block
+  /^#\\s+@doc\\s+${user_cmd}\\s*$/ {
+    if (!restricted) {
+      matched = 1
+    }
+    next
+  }
+
+  # Print the matching line, cut off the leading comment symbols
+  /^#/ { if (matched) print substr(\$0,3) }
+  " < "${REAL_CMD}"
 }
 
 # Bash auto completion support: print subcommands
@@ -137,7 +177,31 @@ function cmd {
   subcommand "$@"
 }
 
-source "${REAL_CMD}"
+# Only import the functions allowed for the current role
+source <(awk -vrole="${ROLE}" '
+          # Initially assume everything is allowed
+          BEGIN { restricted = 0 }
+
+          /^#\s+@restrict\s+[^\s]+/ {
+            # If there is @restrict, assume the function is not allowed
+            restricted = 1
+            split($4,roles,",")
+            for (i = 0; i < length(roles); i++) {
+              if (roles[i] == role) {
+                # If the role matches, allow the function
+                restricted = 0
+              }
+            }
+          }
+
+          {
+            if (!restricted) print
+          }
+
+          # End of top-level block means end of restricted function
+          /^\}/ { restricted = 0; }
+
+          ' ${REAL_CMD})
 
 if [[ $# -ne 0 ]] && [[ $1 == autocomplete ]]; then
   # Special case - request for bash autocompletion

--- a/clicmd
+++ b/clicmd
@@ -7,6 +7,41 @@
 # prevent modification of executable path
 PATH="/bin:/sbin:/usr/bin:/usr/sbin"
 
+# Role related definitions
+ROLE_ADMIN="admin"
+ROLE_OPERATOR="operator"
+ROLE_USER="user"
+
+GROUP_ADMIN="%GROUP_ADMIN%"
+GROUP_OPERATOR="%GROUP_OPERATOR%"
+GROUP_USER="%GROUP_USER%"
+
+# Lookup for group by role name (privilege in BMC terms)
+function role_to_group {
+  case "$1" in
+    ${ROLE_ADMIN})    echo "${GROUP_ADMIN}";;
+    ${ROLE_OPERATOR}) echo "${GROUP_OPERATOR}";;
+    ${ROLE_USER})     echo "${GROUP_USER}";;
+    *)
+      echo "Invalid role name: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Lookup for role (privilege in BMC terms) by group name
+function group_to_role {
+  case "$1" in
+    ${GROUP_ADMIN})    echo "${ROLE_ADMIN}";;
+    ${GROUP_OPERATOR}) echo "${ROLE_OPERATOR}";;
+    ${GROUP_USER})     echo "${ROLE_USER}";;
+    *)
+      echo "Invalid group name: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
 # command to execute
 USER_CMD="${BASH_SOURCE[0]}"
 REAL_CMD="/usr/share/cli/$(basename "${USER_CMD}")"

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -64,7 +64,6 @@ function cmd_info_uptime {
 }
 
 # @sudo cmd_info_version admin,operator,user
-# @restrict cmd_info_version admin,operator,user
 # @doc cmd_info_version
 # Show version of BMC and BIOS/UEFI
 #   -b, --bmc   Show BMC version
@@ -199,14 +198,14 @@ function cmd_ifconfig {
   netconfig "$@"
 }
 
+# @restrict cmd_syslog admin
 # @doc cmd_syslog
 # Remote logging settings
 function cmd_syslog {
   subcommand "$@"
 }
 
-# @sudo cmd_syslog_show admin,operator,user
-# @restrict cmd_syslog_show admin,operator,user
+# @sudo cmd_syslog_show admin
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
@@ -267,8 +266,10 @@ function cmd_syslog_reset {
     cmd_syslog_set :0
 }
 
-# @doc cmd_snmp
-# Syslog server configuration
+## @sudo cmd_snmp admin,operator
+## @restrict cmd_snmp admin,operator
+## @doc cmd_snmp
+## Syslog server configuration
 #function cmd_snmp {
 #  not implemented
 #}
@@ -323,6 +324,7 @@ function cmd_config_default {
   fwupdate --reset
 }
 
+# @restrict cmd_update admin
 # @doc cmd_update
 # BMC and BIOS update
 function cmd_update {
@@ -363,14 +365,19 @@ function cmd_update_start {
   fwupdate ${reset} ${yes} -f "${fwfile}"
 }
 
-# @doc cmd_update_status
-# Returns the status of the firmware update process
+# Update the parent command's @sudo when implement this
+## @sudo cmd_update_rollback admin,operator
+## @restrict cmd_update_rollback admin,operator
+## @doc cmd_update_status
+## Returns the status of the firmware update process
 #function cmd_update_status {
 #  not implemented
 #}
 
-# @doc cmd_update_rollback
-# Rollback to the standby firmware
+## @sudo cmd_update_rollback admin
+## @restrict cmd_update_rollback admin
+## @doc cmd_update_rollback
+## Rollback to the standby firmware
 #function cmd_update_rollback {
 #  not implemented
 #}

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -64,6 +64,7 @@ function cmd_info_uptime {
 }
 
 # @sudo cmd_info_version admin,operator,user
+# @restrict cmd_info_version admin,operator,user
 # @doc cmd_info_version
 # Show version of BMC and BIOS/UEFI
 #   -b, --bmc   Show BMC version
@@ -100,6 +101,7 @@ function cmd_datetime {
 }
 
 # @sudo cmd_datetime_method admin
+# @restrict cmd_datetime_method admin
 # @doc cmd_datetime_method
 # Change time synchronization method
 #  {manual|ntp}
@@ -142,6 +144,7 @@ function cmd_datetime_method {
 }
 
 # @sudo cmd_datetime_set admin
+# @restrict cmd_datetime_set admin
 # @doc cmd_datetime_set
 # Set system time manually
 #   YYYY-MM-DD-HH-mm-SS   Time to set
@@ -177,6 +180,7 @@ function cmd_datetime_show {
 }
 
 # @sudo cmd_datetime_ntpconfig admin
+# @restrict cmd_datetime_ntpconfig admin
 # @doc cmd_datetime_ntpconfig
 # Configure NTP server connection
 #  {add|del} IP
@@ -188,6 +192,7 @@ function cmd_datetime_ntpconfig {
 }
 
 # @sudo cmd_ifconfig admin
+# @restrict cmd_ifconfig admin
 # @doc cmd_ifconfig
 # BMC network configuration
 function cmd_ifconfig {
@@ -201,6 +206,7 @@ function cmd_syslog {
 }
 
 # @sudo cmd_syslog_show admin,operator,user
+# @restrict cmd_syslog_show admin,operator,user
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
@@ -230,6 +236,7 @@ function cmd_syslog_show {
 }
 
 # @sudo cmd_syslog_set admin
+# @restrict cmd_syslog_set admin
 # @doc cmd_syslog_set
 # Configure remote syslog server
 #  address[:port] - to change settings
@@ -253,6 +260,7 @@ function cmd_syslog_set {
 }
 
 # @sudo cmd_syslog_reset admin
+# @restrict cmd_syslog_reset admin
 # @doc cmd_syslog_reset
 # Reset syslog settins. Alias for the syslog set command without arguments.
 function cmd_syslog_reset {
@@ -272,6 +280,7 @@ function cmd_config {
 }
 
 # @sudo cmd_config_backup admin
+# @restrict cmd_config_backup admin
 # @doc cmd_config_backup
 # Backup the BMC configuration to a file
 #   FILE    backup file
@@ -284,6 +293,7 @@ function cmd_config_backup {
 }
 
 # @sudo cmd_config_restore admin
+# @restrict cmd_config_restore admin
 # @doc cmd_config_restore
 # Restore the BMC configuration from a file
 #   FILE    backup file
@@ -296,6 +306,7 @@ function cmd_config_restore {
 }
 
 # @sudo cmd_config_default admin
+# @restrict cmd_config_default admin
 # @doc cmd_config_default
 # Restore the factory default BMC config
 #  -k, --keepipconfig   Keep network settings
@@ -319,6 +330,7 @@ function cmd_update {
 }
 
 # @sudo cmd_update_start admin
+# @restrict cmd_update_start admin
 # @doc cmd_update_start
 # Update BMC and BIOS.
 #  -c, --clearcfg  Reset BMC settings to manufacture defaults
@@ -364,6 +376,7 @@ function cmd_update_start {
 #}
 
 # @sudo cmd_reboot admin
+# @restrict cmd_reboot admin
 # @doc cmd_reboot
 # Reboot the BMC
 #  -f, --force     Forced BMC reboot

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: General BMC configuration
-#
 
 SETTINGS_SERVICE="xyz.openbmc_project.Settings"
 TIMESYNC_METHOD_PATH="/xyz/openbmc_project/time/sync_method"

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -64,7 +64,6 @@ function cmd_info_uptime {
 }
 
 # @sudo cmd_info_version admin,operator,user
-# @restrict cmd_info_version admin,operator,user
 # @doc cmd_info_version
 # Show version of BMC and BIOS/UEFI
 #   -b, --bmc   Show BMC version
@@ -199,14 +198,14 @@ function cmd_ifconfig {
   netconfig "$@"
 }
 
+# @restrict cmd_syslog admin
 # @doc cmd_syslog
 # Remote logging settings
 function cmd_syslog {
   subcommand "$@"
 }
 
-# @sudo cmd_syslog_show admin,operator,user
-# @restrict cmd_syslog_show admin,operator,user
+# @sudo cmd_syslog_show admin
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
@@ -267,6 +266,7 @@ function cmd_syslog_reset {
     cmd_syslog_set :0
 }
 
+# @restrict cmd_config admin
 # @doc cmd_config
 # BMC config backup and restore
 function cmd_config {
@@ -291,6 +291,7 @@ function cmd_config_default {
   fwupdate --reset
 }
 
+# @restrict cmd_update admin
 # @doc cmd_update
 # BMC and BIOS update
 function cmd_update {
@@ -365,6 +366,7 @@ function cmd_reboot {
   reboot ${force}
 }
 
+# @restrict cmd_remoteimage admin
 # @doc cmd_remoteimage
 # Access to the remote side file
 function cmd_remoteimage {

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -64,6 +64,7 @@ function cmd_info_uptime {
 }
 
 # @sudo cmd_info_version admin,operator,user
+# @restrict cmd_info_version admin,operator,user
 # @doc cmd_info_version
 # Show version of BMC and BIOS/UEFI
 #   -b, --bmc   Show BMC version
@@ -100,6 +101,7 @@ function cmd_datetime {
 }
 
 # @sudo cmd_datetime_method admin
+# @restrict cmd_datetime_method admin
 # @doc cmd_datetime_method
 # Change time synchronization method
 #  {manual|ntp}
@@ -142,6 +144,7 @@ function cmd_datetime_method {
 }
 
 # @sudo cmd_datetime_set admin
+# @restrict cmd_datetime_set admin
 # @doc cmd_datetime_set
 # Set system time manually
 #   YYYY-MM-DD-HH-mm-SS   Time to set
@@ -177,6 +180,7 @@ function cmd_datetime_show {
 }
 
 # @sudo cmd_datetime_ntpconfig admin
+# @restrict cmd_datetime_ntpconfig admin
 # @doc cmd_datetime_ntpconfig
 # Configure NTP server connection
 #  {interface} {add|del} IP
@@ -188,6 +192,7 @@ function cmd_datetime_ntpconfig {
 }
 
 # @sudo cmd_ifconfig admin
+# @restrict cmd_ifconfig admin
 # @doc cmd_ifconfig
 # BMC network configuration
 function cmd_ifconfig {
@@ -201,6 +206,7 @@ function cmd_syslog {
 }
 
 # @sudo cmd_syslog_show admin,operator,user
+# @restrict cmd_syslog_show admin,operator,user
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
@@ -230,6 +236,7 @@ function cmd_syslog_show {
 }
 
 # @sudo cmd_syslog_set admin
+# @restrict cmd_syslog_set admin
 # @doc cmd_syslog_set
 # Configure remote syslog server
 #  address[:port] - to change settings
@@ -253,6 +260,7 @@ function cmd_syslog_set {
 }
 
 # @sudo cmd_syslog_reset admin
+# @restrict cmd_syslog_reset admin
 # @doc cmd_syslog_reset
 # Reset syslog settins. Alias for the syslog set command without arguments.
 function cmd_syslog_reset {
@@ -266,6 +274,7 @@ function cmd_config {
 }
 
 # @sudo cmd_config_default admin
+# @restrict cmd_config_default admin
 # @doc cmd_config_default
 # Restore the factory default BMC config
 #  -k, --keepipconfig   Keep network settings
@@ -289,6 +298,7 @@ function cmd_update {
 }
 
 # @sudo cmd_update_start admin
+# @restrict cmd_update_start admin
 # @doc cmd_update_start
 # Update BMC and BIOS.
 #  -c, --clearcfg  Reset BMC settings to manufacture defaults
@@ -322,6 +332,7 @@ function cmd_update_start {
 }
 
 # @sudo cmd_reboot admin
+# @restrict cmd_reboot admin
 # @doc cmd_reboot
 # Reboot the BMC
 #  -f, --force     Forced BMC reboot
@@ -361,6 +372,7 @@ function cmd_remoteimage {
 }
 
 # @sudo cmd_remoteimage_connect admin
+# @restrict cmd_remoteimage_connect admin
 # @doc cmd_remoteimage_connect
 # Connect to the remote server via the specified protocol
 #   --nbd <0..10>         use NBD protocol to connect the remote server with specified NBD device number
@@ -423,6 +435,7 @@ function cmd_remoteimage_connect {
 }
 
 # @sudo cmd_remoteimage_disconnect admin
+# @restrict cmd_remoteimage_disconnect admin
 # @doc cmd_remoteimage_disconnect
 # Disconnect NBD session
 #   -y, --yes       do not ask for confirmation

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: General BMC configuration
-#
 
 SETTINGS_SERVICE="xyz.openbmc_project.Settings"
 TIMESYNC_METHOD_PATH="/xyz/openbmc_project/time/sync_method"

--- a/commands/diagnostics.nicole
+++ b/commands/diagnostics.nicole
@@ -17,7 +17,6 @@ function cmd_led {
 }
 
 # @sudo cmd_led_status admin,operator,user
-# @restrict cmd_led_status admin,operator,user
 # @doc cmd_led_status
 # Check the identification LED status
 function cmd_led_status {
@@ -57,50 +56,56 @@ function cmd_led_off {
   cmd_led_status
 }
 
-# @doc cmd_intrusion
-# Intrusion sensor operations
+## @doc cmd_intrusion
+## Intrusion sensor operations
 #function cmd_intrusion {
 #  subcommand "$@"
 #}
 
-# @doc cmd_intrusion_show
-# Show status of intrusion alert
+## @doc cmd_intrusion_show
+## Show status of intrusion alert
 #function cmd_intrusion_show {
 #  not implemented
 #}
 
-# @doc cmd_intrusion_clear
-# Clear intrusion alert
+## @sudo cmd_intrusion_clear admin
+## @restrict cmd_intrusion_clear admin
+## @doc cmd_intrusion_clear
+## Clear intrusion alert
 #function cmd_intrusion_clear {
 #  not implemented
 #}
 
-# @doc cmd_callhome
-# CallHome operations
+## @doc cmd_callhome
+## CallHome operations
 #function cmd_callhome {
 #  subcommand "$@"
 #}
 
-# @doc cmd_callhome_configure
-# Configure location for CallHome reports
+## @sudo cmd_callhome_configure admin
+## @restrict cmd_callhome_configure admin
+## @doc cmd_callhome_configure
+## Configure location for CallHome reports
 #function cmd_callhome_configure {
 #  not implemented
 #}
 
-# @doc cmd_callhome_send
-# Send CallHome report
+## @doc cmd_callhome_send
+## Send CallHome report
 #function cmd_callhome_send {
 #  not implemented
 #}
 
-# @doc cmd_callhome_use
-# Toggle CallHome feature
+## @sudo cmd_callhome_use admin
+## @restrict cmd_callhome_use admin
+## @doc cmd_callhome_use
+## Toggle CallHome feature
 #function cmd_callhome_use {
 #  not implemented
 #}
 
-# @doc cmd_callhome_status
-# Check CallHome feature status
+## @doc cmd_callhome_status
+## Check CallHome feature status
 #function cmd_callhome_status {
 #  not implemented
 #}

--- a/commands/diagnostics.nicole
+++ b/commands/diagnostics.nicole
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: Diagnostic operations
-#
 
 # D-Bus object descriptions to manage the LED
 LED_DBUS_SERVICE="xyz.openbmc_project.LED.GroupManager"

--- a/commands/diagnostics.nicole
+++ b/commands/diagnostics.nicole
@@ -17,6 +17,7 @@ function cmd_led {
 }
 
 # @sudo cmd_led_status admin,operator,user
+# @restrict cmd_led_status admin,operator,user
 # @doc cmd_led_status
 # Check the identification LED status
 function cmd_led_status {
@@ -33,6 +34,7 @@ function cmd_led_status {
 }
 
 # @sudo cmd_led_on admin,operator
+# @restrict cmd_led_on admin,operator
 # @doc cmd_led_on
 # Turn the identification LED on
 function cmd_led_on {
@@ -44,6 +46,7 @@ function cmd_led_on {
 }
 
 # @sudo cmd_led_off admin,operator
+# @restrict cmd_led_off admin,operator
 # @doc cmd_led_off
 # Turn the identification LED off
 function cmd_led_off {
@@ -147,6 +150,7 @@ function supportbundle_direct {
 }
 
 # @sudo cmd_supportbundle admin,operator
+# @restrict cmd_supportbundle admin,operator
 # @doc cmd_supportbundle
 # Report for techsupport
 function cmd_supportbundle {

--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: Diagnostic operations
-#
 
 # D-Bus object descriptions to manage the LED
 LED_DBUS_SERVICE="xyz.openbmc_project.LED.GroupManager"

--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -17,7 +17,6 @@ function cmd_led {
 }
 
 # @sudo cmd_led_status admin,operator,user
-# @restrict cmd_led_status admin,operator,user
 # @doc cmd_led_status
 # Check the identification LED status
 function cmd_led_status {

--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -17,6 +17,7 @@ function cmd_led {
 }
 
 # @sudo cmd_led_status admin,operator,user
+# @restrict cmd_led_status admin,operator,user
 # @doc cmd_led_status
 # Check the identification LED status
 function cmd_led_status {
@@ -33,6 +34,7 @@ function cmd_led_status {
 }
 
 # @sudo cmd_led_on admin,operator
+# @restrict cmd_led_on admin,operator
 # @doc cmd_led_on
 # Turn the identification LED on
 function cmd_led_on {
@@ -44,6 +46,7 @@ function cmd_led_on {
 }
 
 # @sudo cmd_led_off admin,operator
+# @restrict cmd_led_off admin,operator
 # @doc cmd_led_off
 # Turn the identification LED off
 function cmd_led_off {

--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: System health information
-#
 
 # @sudo cmd_inventory admin,operator
 # @restrict cmd_inventory admin,operator

--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -5,6 +5,7 @@
 #
 
 # @sudo cmd_inventory admin,operator
+# @restrict cmd_inventory admin,operator
 # @doc cmd_inventory
 # System inventory
 function cmd_inventory {
@@ -12,6 +13,7 @@ function cmd_inventory {
 }
 
 # @sudo cmd_sensors admin,operator
+# @restrict cmd_sensors admin,operator
 # @doc cmd_sensors
 # Sensor readings
 function cmd_sensors {
@@ -39,6 +41,7 @@ function cmd_logs_list {
 }
 
 # @sudo cmd_logs_show admin,operator
+# @restrict cmd_logs_show admin,operator
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
@@ -57,6 +60,7 @@ function cmd_logs_show {
 }
 
 # @sudo cmd_logs_export admin,operator
+# @restrict cmd_logs_export admin,operator
 # @doc cmd_logs_export
 # Export system logs
 function cmd_logs_export {
@@ -82,6 +86,7 @@ function cmd_logs_export {
 }
 
 # @sudo cmd_logs_clear admin
+# @restrict cmd_logs_clear admin
 # @doc cmd_logs_clear
 # Clear system logs
 function cmd_logs_clear {
@@ -93,6 +98,7 @@ function cmd_logs_clear {
 }
 
 # @sudo cmd_sel admin,operator
+# @restrict cmd_sel admin,operator
 # @doc cmd_sel
 # Decode eSEL
 #  ID    Shown eSEL record with specified ID

--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -40,8 +40,7 @@ function cmd_logs_list {
     done
 }
 
-# @sudo cmd_logs_show admin,operator
-# @restrict cmd_logs_show admin,operator
+# @sudo cmd_logs_show admin,operator,user
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
@@ -59,8 +58,7 @@ function cmd_logs_show {
   abort_badarg "${name}"
 }
 
-# @sudo cmd_logs_export admin,operator
-# @restrict cmd_logs_export admin,operator
+# @sudo cmd_logs_export admin,operator,user
 # @doc cmd_logs_export
 # Export system logs
 function cmd_logs_export {

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: System health information
-#
 
 # @sudo cmd_inventory admin,operator,user
 # @restrict cmd_inventory admin,operator,user

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -5,6 +5,7 @@
 #
 
 # @sudo cmd_inventory admin,operator
+# @restrict cmd_inventory admin,operator
 # @doc cmd_inventory
 # System inventory
 function cmd_inventory {
@@ -12,6 +13,7 @@ function cmd_inventory {
 }
 
 # @sudo cmd_sensors admin,operator
+# @restrict cmd_sensors admin,operator
 # @doc cmd_sensors
 # Sensor readings
 function cmd_sensors {
@@ -39,6 +41,7 @@ function cmd_logs_list {
 }
 
 # @sudo cmd_logs_show admin,operator
+# @restrict cmd_logs_show admin,operator
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
@@ -57,6 +60,7 @@ function cmd_logs_show {
 }
 
 # @sudo cmd_logs_export admin,operator
+# @restrict cmd_logs_export admin,operator
 # @doc cmd_logs_export
 # Export system logs
 function cmd_logs_export {
@@ -82,6 +86,7 @@ function cmd_logs_export {
 }
 
 # @sudo cmd_logs_clear admin
+# @restrict cmd_logs_clear admin
 # @doc cmd_logs_clear
 # Clear system logs
 function cmd_logs_clear {

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -4,16 +4,16 @@
 # CLI: System health information
 #
 
-# @sudo cmd_inventory admin,operator
-# @restrict cmd_inventory admin,operator
+# @sudo cmd_inventory admin,operator,user
+# @restrict cmd_inventory admin,operator,user
 # @doc cmd_inventory
 # System inventory
 function cmd_inventory {
   ipmitool fru
 }
 
-# @sudo cmd_sensors admin,operator
-# @restrict cmd_sensors admin,operator
+# @sudo cmd_sensors admin,operator,user
+# @restrict cmd_sensors admin,operator,user
 # @doc cmd_sensors
 # Sensor readings
 function cmd_sensors {
@@ -40,8 +40,8 @@ function cmd_logs_list {
     done
 }
 
-# @sudo cmd_logs_show admin,operator
-# @restrict cmd_logs_show admin,operator
+# @sudo cmd_logs_show admin,operator,user
+# @restrict cmd_logs_show admin,operator,user
 # @doc cmd_logs_show
 # Get system logs
 function cmd_logs_show {
@@ -59,8 +59,8 @@ function cmd_logs_show {
   abort_badarg "${name}"
 }
 
-# @sudo cmd_logs_export admin,operator
-# @restrict cmd_logs_export admin,operator
+# @sudo cmd_logs_export admin,operator,user
+# @restrict cmd_logs_export admin,operator,user
 # @doc cmd_logs_export
 # Export system logs
 function cmd_logs_export {

--- a/commands/host.nicole
+++ b/commands/host.nicole
@@ -4,8 +4,7 @@
 # CLI: Host operations
 #
 
-# @sudo cmd_info admin,operator
-# @restrict cmd_info admin,operator
+# @sudo cmd_info admin,operator,user
 # @doc cmd_info
 # View the general host information
 function cmd_info {
@@ -19,36 +18,39 @@ function cmd_boot {
   subcommand "$@"
 }
 
-# @doc cmd_boot_next
-# Choose boot source for the next boot
-#   -l, --local
-#   -p, --pxe
-#   -s, --san
-#   -u, --usb
-#   -m, --media
+## @sudo cmd_boot_next admin
+## @restrict cmd_boot_next admin
+## @doc cmd_boot_next
+## Choose boot source for the next boot
+##   -l, --local
+##   -p, --pxe
+##   -s, --san
+##   -u, --usb
+##   -m, --media
 #function cmd_boot_next {
 #  not implemented
 #}
 
-# @doc cmd_boot_persistent
-# Choose default boot source
-#   -l, --local
-#   -p, --pxe
-#   -s, --san
-#   -u, --usb
-#   -m, --media
+## @sudo cmd_boot_persistent admin
+## @restrict cmd_boot_persistent admin
+## @doc cmd_boot_persistent
+## Choose default boot source
+##   -l, --local
+##   -p, --pxe
+##   -s, --san
+##   -u, --usb
+##   -m, --media
 #function cmd_boot_persistent {
 #  not implemented
 #}
 
-# @doc cmd_boot_status
-# Show actual setting for boot source
+## @doc cmd_boot_show
+## Show actual setting for boot source
 #function cmd_boot_status {
 #  not implemented
 #}
 
-# @sudo cmd_boot_progress admin,operator
-# @restrict cmd_boot_progress admin,operator
+# @sudo cmd_boot_progress admin,operator,user
 # @doc cmd_boot_progress
 # Show host boot progress status
 function cmd_boot_progress {
@@ -109,14 +111,15 @@ function cmd_power_off {
   fi
 }
 
-# @doc cmd_power_reboot
-# Performs host reboot
+## @sudo cmd_power_reboot admin,operator
+## @restrict cmd_power_reboot admin,operator
+## @doc cmd_power_reboot
+## Performs host reboot
 #function cmd_power_reboot {
 #  not implemented
 #}
 
-# @sudo cmd_power_status admin,operator
-# @restrict cmd_power_status admin,operator
+# @sudo cmd_power_status admin,operator,user
 # @doc cmd_power_status
 # Get host power status
 function cmd_power_status {
@@ -124,20 +127,24 @@ function cmd_power_status {
   obmcutil status | sed 's/xyz.*\.//'
 }
 
-# @doc cmd_power_capping
-# Configure power capping
-#   -d, --disable       Disable power capping
-#   -e, --enable WATTS  Enable power capping
+## @sudo cmd_power_capping admin
+## @restrict cmd_power_capping admin
+## @doc cmd_power_capping
+## Configure power capping
+##   -d, --disable       Disable power capping
+##   -e, --enable WATTS  Enable power capping
 #function cmd_power_capping {
 #  not implemented
 #}
 
-# @doc cmd_power_usage
-# View power usage
+## @doc cmd_power_usage
+## View power usage
 #function cmd_power_usage {
 #  not implemented
 #}
 
+# @sudo cmd_console admin,user
+# @restrict cmd_console admin,user
 # @doc cmd_console
 # Open virtual console
 function cmd_console {
@@ -227,35 +234,44 @@ function cmd_nmi {
   echo "SRESET signal has been sent, expect kdump on the host."
 }
 
-# @doc cmd_virtualmedia
-# Virtual media operations
+## @restrict cmd_virtualmedia admin
+## @doc cmd_virtualmedia
+## Virtual media operations
 #function cmd_virtualmedia {
 #  subcommand "$@"
 #}
 
-# @doc cmd_virtualmedia_mount
-# Mount a virtual media
-#  -p, --path <location> — path to image file
-#  -u, --user <username> — username to access the share
-#  -r, --readonly — mount virtual media in read-only mode
+## @sudo cmd_virtualmedia_mount admin
+## @restrict cmd_virtualmedia_mount admin
+## @doc cmd_virtualmedia_mount
+## Mount a virtual media
+##  -p, --path <location> — path to image file
+##  -u, --user <username> — username to access the share
+##  -r, --readonly — mount virtual media in read-only mode
 #function cmd_virtualmedia_mount {
 #  not implemented
 #}
 
-# @doc cmd_virtualmedia_unmount
-# Unmount the virtual media
+## @sudo cmd_virtualmedia_unmount admin
+## @restrict cmd_virtualmedia_unmount admin
+## @doc cmd_virtualmedia_unmount
+## Unmount the virtual media
 #function cmd_virtualmedia_unmount {
 #  not implemented
 #}
 
-# @doc cmd_virtualmedia_writeprotection
-# Enable or disable virtual media write protection
+## @sudo cmd_virtualmedia_writeprotection admin
+## @restrict cmd_virtualmedia_writeprotection admin
+## @doc cmd_virtualmedia_writeprotection
+## Enable or disable virtual media write protection
 #function cmd_virtualmedia_writeprotection {
 #  not implemented
 #}
 
-# @doc cmd_virtualmedia_status
-# Check the virtual media status
+## @sudo cmd_virtualmedia_status admin
+## @restrict cmd_virtualmedia_status admin
+## @doc cmd_virtualmedia_status
+## Check the virtual media status
 #function cmd_virtualmedia_status {
 #  not implemented
 #}

--- a/commands/host.nicole
+++ b/commands/host.nicole
@@ -5,6 +5,7 @@
 #
 
 # @sudo cmd_info admin,operator
+# @restrict cmd_info admin,operator
 # @doc cmd_info
 # View the general host information
 function cmd_info {
@@ -47,6 +48,7 @@ function cmd_boot {
 #}
 
 # @sudo cmd_boot_progress admin,operator
+# @restrict cmd_boot_progress admin,operator
 # @doc cmd_boot_progress
 # Show host boot progress status
 function cmd_boot_progress {
@@ -61,6 +63,7 @@ function cmd_power {
 }
 
 # @sudo cmd_power_on admin,operator
+# @restrict cmd_power_on admin,operator
 # @doc cmd_power_on
 # Turn the host on
 function cmd_power_on {
@@ -70,6 +73,7 @@ function cmd_power_on {
 }
 
 # @sudo cmd_power_off admin,operator
+# @restrict cmd_power_off admin,operator
 # @doc cmd_power_off
 # Turn the host off
 #  -f, --forced    Forced shutdown
@@ -112,6 +116,7 @@ function cmd_power_off {
 #}
 
 # @sudo cmd_power_status admin,operator
+# @restrict cmd_power_status admin,operator
 # @doc cmd_power_status
 # Get host power status
 function cmd_power_status {
@@ -192,6 +197,7 @@ function nmi_nicole {
 }
 
 # @sudo cmd_nmi admin
+# @restrict cmd_nmi admin
 # @doc cmd_nmi
 # Send NMI signal to host to dump the hanged kernel
 #  -y, --yes       Do not ask for confirmation

--- a/commands/host.nicole
+++ b/commands/host.nicole
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
-# CLI: Host operations
-#
+# CLI: Host control operations
 
 # @sudo cmd_info admin,operator,user
 # @doc cmd_info

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -11,6 +11,7 @@ function cmd_power {
 }
 
 # @sudo cmd_power_on admin,operator
+# @restrict cmd_power_on admin,operator
 # @doc cmd_power_on
 # Turn the host on
 function cmd_power_on {
@@ -20,6 +21,7 @@ function cmd_power_on {
 }
 
 # @sudo cmd_power_off admin,operator
+# @restrict cmd_power_off admin,operator
 # @doc cmd_power_off
 # Turn the host off
 #  -f, --forced    Forced shutdown
@@ -56,6 +58,7 @@ function cmd_power_off {
 }
 
 # @sudo cmd_power_status admin,operator
+# @restrict cmd_power_status admin,operator
 # @doc cmd_power_status
 # Get host power status
 function cmd_power_status {
@@ -70,6 +73,7 @@ function cmd_virtualmedia {
 }
 
 # @sudo cmd_virtualmedia_mount admin
+# @restrict cmd_virtualmedia_mount admin
 # @doc cmd_virtualmedia_mount
 # Mount a virtual media
 #  --usb    - the USB interface type
@@ -112,6 +116,7 @@ function cmd_virtualmedia_mount {
 }
 
 # @sudo cmd_virtualmedia_umount admin
+# @restrict cmd_virtualmedia_umount admin
 # @doc cmd_virtualmedia_umount
 # Unmount the virtual media
 #  -y, --yes  - does not ask for interactive confirmation

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
-# CLI: Host operations
-#
+# CLI: Host control operations
 
 # @doc cmd_power
 # Host power actions, capping and usage

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -57,8 +57,15 @@ function cmd_power_off {
   fi
 }
 
-# @sudo cmd_power_status admin,operator
-# @restrict cmd_power_status admin,operator
+## @sudo cmd_power_reboot admin,operator
+## @restrict cmd_power_status admin,operator
+## @doc cmd_power_reboot
+## Performs host reboot
+#function cmd_power_reboot {
+#  not implemented
+#}
+
+# @sudo cmd_power_status admin,operator,user
 # @doc cmd_power_status
 # Get host power status
 function cmd_power_status {
@@ -66,6 +73,24 @@ function cmd_power_status {
   ipmitool power status
 }
 
+## @sudo cmd_power_capping admin
+## @restrict cmd_power_capping admin
+## @doc cmd_power_capping
+## Configure power capping
+##   -d, --disable       Disable power capping
+##   -e, --enable WATTS  Enable power capping
+#function cmd_power_capping {
+#  not implemented
+#}
+
+## @doc cmd_power_usage
+## View power usage
+#function cmd_power_usage {
+#  not implemented
+#}
+
+# @sudo cmd_virtualmedia admin
+# @restrict cmd_virtualmedia admin
 # @doc cmd_virtualmedia
 # Access Virtual Media
 function cmd_virtualmedia {
@@ -138,6 +163,8 @@ function cmd_virtualmedia_umount {
   usb-ctrl eject "usb.ms.cli"
 }
 
+# @sudo cmd_console admin,user
+# @restrict cmd_console admin,user
 # @doc cmd_console
 # Open virtual console
 function cmd_console {

--- a/commands/user
+++ b/commands/user
@@ -18,6 +18,7 @@ DBUS_DELETE="xyz.openbmc_project.Object.Delete"
 USERNAME_REGEX="^[\.a-zA-Z0-9_-]+$"
 
 # @sudo cmd_create admin
+# @restrict cmd_create admin
 # @doc cmd_create
 # Create a new user
 #   -n, --name NAME   User name
@@ -57,6 +58,7 @@ function cmd_create {
 }
 
 # @sudo cmd_show admin
+# @restrict cmd_show admin
 # @doc cmd_show
 # Show specific user
 #   USERNAME...    Show user with specific name (multiple names can be added)
@@ -78,6 +80,7 @@ function cmd_show {
 }
 
 # @sudo cmd_list admin
+# @restrict cmd_list admin
 # @doc cmd_list
 # Show list of users
 function cmd_list {
@@ -88,6 +91,7 @@ function cmd_list {
 }
 
 # @sudo cmd_delete admin
+# @restrict cmd_delete admin
 # @doc cmd_delete
 # Delete users
 #   -y, --yes       Do not ask for confirmation
@@ -141,6 +145,7 @@ function cmd_set {
 }
 
 # @sudo cmd_set_password admin
+# @restrict cmd_set_password admin
 # @doc cmd_set_password
 # Update user password
 #   USERNAME    User account name
@@ -158,6 +163,7 @@ function cmd_set_password {
 }
 
 # @sudo cmd_set_role admin
+# @restrict cmd_set_role admin
 # @doc cmd_set_role
 # Update user role
 #   -n, --name NAME   User name

--- a/commands/user
+++ b/commands/user
@@ -4,13 +4,6 @@
 # CLI: User management
 #
 
-ROLE_ADMIN="admin"
-ROLE_OPERATOR="operator"
-ROLE_USER="user"
-
-GROUP_ADMIN="%GROUP_ADMIN%"
-GROUP_OPERATOR="%GROUP_OPERATOR%"
-GROUP_USER="%GROUP_USER%"
 GROUP_IPMI="ipmi"
 GROUP_REDFISH="redfish"
 GROUP_WEB="web"
@@ -23,32 +16,6 @@ DBUS_ATTRIBUTES="xyz.openbmc_project.User.Attributes"
 DBUS_DELETE="xyz.openbmc_project.Object.Delete"
 
 USERNAME_REGEX="^[\.a-zA-Z0-9_-]+$"
-
-# Lookup for group by role name (privilege in BMC terms)
-function role_to_group {
-  case "$1" in
-    ${ROLE_ADMIN})    echo "${GROUP_ADMIN}";;
-    ${ROLE_OPERATOR}) echo "${GROUP_OPERATOR}";;
-    ${ROLE_USER})     echo "${GROUP_USER}";;
-    *)
-      echo "Invalid role name: $1" >&2
-      return 1
-      ;;
-  esac
-}
-
-# Lookup for role (privilege in BMC terms) by group name
-function group_to_role {
-  case "$1" in
-    ${GROUP_ADMIN})    echo "${ROLE_ADMIN}";;
-    ${GROUP_OPERATOR}) echo "${ROLE_OPERATOR}";;
-    ${GROUP_USER})     echo "${ROLE_USER}";;
-    *)
-      echo "Invalid group name: $1" >&2
-      return 1
-      ;;
-  esac
-}
 
 # @sudo cmd_create admin
 # @doc cmd_create

--- a/commands/user
+++ b/commands/user
@@ -26,6 +26,11 @@ USERNAME_REGEX="^[\.a-zA-Z0-9_-]+$"
 function cmd_create {
   local name=""
   local role="${ROLE_USER}"
+  if [[ $# -eq 0 ]]; then
+    user create help
+    return 1
+  fi
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -n | --name)
@@ -160,6 +165,13 @@ function cmd_set_password {
     return 1
   fi
   passwd "${name}"
+}
+
+# @doc cmd_set_mypassword
+# Change own password
+function cmd_set_mypassword {
+  expect_noarg "$@"
+  passwd
 }
 
 # @sudo cmd_set_role admin

--- a/commands/user
+++ b/commands/user
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
+#
+# YADRO OpenBMC Command Line Interface
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-#
 # CLI: User management
-#
 
 GROUP_IPMI="ipmi"
 GROUP_REDFISH="redfish"

--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ install_cli_script() {
   unset sudo_file link_file real_file cmd_desc cmd_name src_file
 }
 
-echo "Install Phosphor CLI environment to ${INSTALL_ROOT}"
+echo "Installing Phosphor CLI environment to '${INSTALL_ROOT}' for '${MACHINE}':"
 
 install -DT --mode 0555 "${THIS_DIR}/clicmd" "${INSTALL_ROOT}/usr/bin/clicmd"
 install -DT --mode 0644 "${THIS_DIR}/profile.in" "${INSTALL_ROOT}${DEFAULT_PROFILE}"
@@ -133,10 +133,11 @@ install -DT --mode 0644 "${THIS_DIR}/functions" \
 for SRC_FILE in "${THIS_DIR}/commands"/*; do
   # filter out by target machine
   SRC_TARGET="$(basename "${SRC_FILE}" | sed -r 's/.+\.(.+)|.*/\1/')"
+  printf "Script %-25s" "'$(basename "${SRC_FILE}")'"
   if [ -n "${SRC_TARGET}" -a "${SRC_TARGET}" != "${MACHINE}" ]; then
-    echo "Skip '$(basename "${SRC_FILE}")' (${SRC_TARGET}!=${MACHINE})"
+    echo "[SKIP]"
   else
-    echo "Install '$(basename "${SRC_FILE}")' command script"
+    echo "[INSTALL]"
     install_cli_script "${SRC_FILE}"
   fi
 done

--- a/install.sh
+++ b/install.sh
@@ -158,4 +158,9 @@ for SRC_FILE in "${THIS_DIR}/commands"/*; do
   fi
 done
 
+# do not lecture users on the rules of sudo because
+# sudo is prohibited by default when CLI is installed
+echo "Defaults:ALL passwd_tries = 0, lecture = never" \
+     > ${INSTALL_ROOT}${SUDO_DIR}/sudo_defaults
+
 echo "Installation completed successfully"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,9 @@
 #!/bin/sh -eu
-
 #
-# Installer.
+# YADRO OpenBMC Command Line Interface Installer
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 THIS_DIR="$(realpath "$(dirname "$0")")"

--- a/profile.in
+++ b/profile.in
@@ -1,13 +1,18 @@
 #!/bin/bash
-
 #
-# Default profile.
+# YADRO OpenBMC Command Line Interface
+# Default profile
+# Copyright (C) 2020-2021 YADRO
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # greeting
 cat << EOF
-Welcome to BMC for $(sed -n 's/OPENBMC_TARGET_MACHINE="\(.*\)"/\1/p' /etc/os-release) server!
-Type 'help' to print the list of useful commands.
+Welcome to BMC Command Line Interface for $(sed -n 's/OPENBMC_TARGET_MACHINE="\(.*\)"/\1/p' /etc/os-release)!
+Copyright (C) 2020-2021 YADRO
+
+Type 'help' to print the list of available CLI commands.
 EOF
 
 # replace built-in help command


### PR DESCRIPTION
This branch brings a number of changes:

* The `help` command and `help` argument on subcommands now only show
   the commands available to the calling user based on his/her role (priv-* group membership);
* Direct use of `sudo` is now prohibited. It can only be called automatically/indirectly by
   the CLI commands if allowed by the role. The `sudo` lecturing is disabled.
* Command permissions are thoroughly checked/updated to match the CLI design document
* A new command, `user set mypassword` is added as a synonym for `passwd`
  to change the user's own password
* The installation script's output is a bit easier to read :)
* Copyright banners are added, and the word 'server' is removed from the welcome banner