### PR TITLE
Bugfix/bbmc 366 wrong help

### DIFF
--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -180,16 +180,22 @@ function cmd_datetime_show {
   format_date "${compact}" "${utc}" "$(date +%s)"
 }
 
+function call_netconfig() {
+  local FNAME=${FUNCNAME[1]##cmd_}
+  local PNAME="bmc ${FNAME//_/ }"
+  exec -a "${PNAME}" netconfig --cli "$@"
+}
+
 # @sudo cmd_datetime_ntpconfig admin
 # @restrict cmd_datetime_ntpconfig admin
 # @doc cmd_datetime_ntpconfig
 # Configure NTP server connection
-#  {add|del} IP
+#  {add|del} ADDR [ADDR..]
 function cmd_datetime_ntpconfig {
-  if [[ $# -ne 2 ]]; then
-    abort_badarg "Expected exactly 2 arguments"
+  if [[ $# -lt 2 ]]; then
+    abort_badarg "Expected 2 or more arguments"
   fi
-  netconfig ntp "eth0" "$1" "$2"
+  call_netconfig ntp "eth0" "$@"
 }
 
 # @sudo cmd_ifconfig admin
@@ -197,7 +203,7 @@ function cmd_datetime_ntpconfig {
 # @doc cmd_ifconfig
 # BMC network configuration
 function cmd_ifconfig {
-  netconfig "$@"
+  call_netconfig "$@"
 }
 
 # @restrict cmd_syslog admin

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -71,30 +71,28 @@ function cmd_info_uptime {
 # @doc cmd_info_version
 # Show version of BMC and BIOS/UEFI
 #   -b, --bmc   Show BMC version
-#   -u, --bios  Show BIOS/UEFI version
+#   -o, --opfw  Show OpenPOWER Firmware version
 function cmd_info_version {
-  local bmc=""
-  local bios=""
+  local bmc_match='^BMC '
+  local host_match='^Host '
+  local no_match='no-match-pattern'
+  local bmc=${no_match}
+  local host=${no_match}
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -b | --bmc) bmc="y";;
-      -u | --bios) bios="y";;
+      -b | --bmc) bmc=${bmc_match};;
+      -o | --opfw) host=${host_match};;
       *) abort_badarg "$1";;
     esac
     shift
   done
 
-  if [[ -z "${bmc}${bios}" ]]; then
-    bmc="y"
-    bios="y"
+  if [[ -z "${bmc}${host}" ]]; then
+    bmc=${bmc_match}
+    host=${host_match}
   fi
 
-  if [[ -n "${bmc}" ]]; then
-    fwupdate --version | grep "^BMC "
-  fi
-  if [[ -n "${bios}" ]]; then
-    fwupdate --version | grep "^Host "
-  fi
+  fwupdate --version | grep -E "(${bmc}|${host})"
 }
 
 # @doc cmd_datetime

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -180,16 +180,25 @@ function cmd_datetime_show {
   format_date "${compact}" "${utc}" "$(date +%s)"
 }
 
+function call_netconfig() {
+  local FNAME=${FUNCNAME[1]##cmd_}
+  local PNAME="bmc ${FNAME//_/ }"
+  exec -a "${PNAME}" netconfig --cli "$@"
+}
+
 # @sudo cmd_datetime_ntpconfig admin
 # @restrict cmd_datetime_ntpconfig admin
 # @doc cmd_datetime_ntpconfig
 # Configure NTP server connection
-#  {interface} {add|del} IP
 function cmd_datetime_ntpconfig {
-  if [[ $# -ne 3 ]]; then
-    abort_badarg "Expected exactly 3 arguments"
+  if [[ $# -ge 1 && $1 =~ ^-*h(elp)?$ ]]; then
+    call_netconfig help ntp
+    return
   fi
-  netconfig ntp "$1" "$2" "$3"
+  if [[ $# -lt 3 ]]; then
+    abort_badarg "Expected 3 or more arguments"
+  fi
+  call_netconfig ntp "$@"
 }
 
 # @sudo cmd_ifconfig admin
@@ -197,7 +206,7 @@ function cmd_datetime_ntpconfig {
 # @doc cmd_ifconfig
 # BMC network configuration
 function cmd_ifconfig {
-  netconfig "$@"
+  call_netconfig "$@"
 }
 
 # @restrict cmd_syslog admin

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -73,28 +73,26 @@ function cmd_info_uptime {
 #   -b, --bmc   Show BMC version
 #   -u, --bios  Show BIOS/UEFI version
 function cmd_info_version {
-  local bmc=""
-  local bios=""
+  local bmc_match='^BMC '
+  local host_match='^Host '
+  local no_match='no-match-pattern'
+  local bmc=${no_match}
+  local host=${no_match}
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -b | --bmc) bmc="y";;
-      -u | --bios) bios="y";;
+      -b | --bmc) bmc=${bmc_match};;
+      -u | --bios) host=${host_match};;
       *) abort_badarg "$1";;
     esac
     shift
   done
 
-  if [[ -z "${bmc}${bios}" ]]; then
-    bmc="y"
-    bios="y"
+  if [[ -z "${bmc}${host}" ]]; then
+    bmc=${bmc_match}
+    host=${host_match}
   fi
 
-  if [[ -n "${bmc}" ]]; then
-    fwupdate --version | grep "^BMC "
-  fi
-  if [[ -n "${bios}" ]]; then
-    fwupdate --version | grep "^Host "
-  fi
+  fwupdate --version | grep -E "(${bmc}|${host})"
 }
 
 # @doc cmd_datetime


### PR DESCRIPTION
Requires YADRO-KNS/obmc-yadro-netconfig#9

For vegman, remove the local help from the `bmc datetime ntpconfig`
function description block and implement calling `netconfig` for help.
For nicole, update the local help to be up to date with `netconfig`.

For all targets pass the CLI command name as argv[0] to
`netconfig` and call it with the new `--cli` option so that
`netconfig` displays the CLI command instead of its own name.

Don't call `fwupdate` twice if both host and bmc versions
are requested. Use a single call with a dynamic grep pattern.

Fix command description for OpenPOWER hosts (nicole, vesnin)