### PR TITLE
bmc: Various fixes

### DIFF
--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -73,11 +73,15 @@ function cmd_info_uptime {
 #   -b, --bmc   Show BMC version
 #   -o, --opfw  Show OpenPOWER Firmware version
 function cmd_info_version {
+  # If no options are given, show everything
+  [[ $# -eq 0 ]] && set -- -b -o
+
   local bmc_match='^BMC '
   local host_match='^Host '
   local no_match='no-match-pattern'
   local bmc=${no_match}
   local host=${no_match}
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -b | --bmc) bmc=${bmc_match};;
@@ -86,11 +90,6 @@ function cmd_info_version {
     esac
     shift
   done
-
-  if [[ -z "${bmc}${host}" ]]; then
-    bmc=${bmc_match}
-    host=${host_match}
-  fi
 
   fwupdate --version | grep -E "(${bmc}|${host})"
 }

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -268,7 +268,7 @@ function cmd_syslog_set {
 # @sudo cmd_syslog_reset admin
 # @restrict cmd_syslog_reset admin
 # @doc cmd_syslog_reset
-# Reset syslog settins. Alias for the syslog set command without arguments.
+# Reset syslog settings. Alias for the syslog set command without arguments.
 function cmd_syslog_reset {
     cmd_syslog_set :0
 }

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -162,7 +162,7 @@ function cmd_datetime_set {
 }
 
 # @doc cmd_datetime_show
-# Show system uptime
+# Show system time
 #   -c, --compact   Show last boot time in compact format
 #   -u, --utc       Show last boot time in UTC timezone
 function cmd_datetime_show {

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -271,7 +271,7 @@ function cmd_syslog_set {
 # @sudo cmd_syslog_reset admin
 # @restrict cmd_syslog_reset admin
 # @doc cmd_syslog_reset
-# Reset syslog settins. Alias for the syslog set command without arguments.
+# Reset syslog settings. Alias for the syslog set command without arguments.
 function cmd_syslog_reset {
     cmd_syslog_set :0
 }

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -73,11 +73,15 @@ function cmd_info_uptime {
 #   -b, --bmc   Show BMC version
 #   -u, --bios  Show BIOS/UEFI version
 function cmd_info_version {
+  # If no options are given, show everything
+  [[ $# -eq 0 ]] && set -- -b -u
+
   local bmc_match='^BMC '
   local host_match='^Host '
   local no_match='no-match-pattern'
   local bmc=${no_match}
   local host=${no_match}
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -b | --bmc) bmc=${bmc_match};;
@@ -86,11 +90,6 @@ function cmd_info_version {
     esac
     shift
   done
-
-  if [[ -z "${bmc}${host}" ]]; then
-    bmc=${bmc_match}
-    host=${host_match}
-  fi
 
   fwupdate --version | grep -E "(${bmc}|${host})"
 }

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -162,7 +162,7 @@ function cmd_datetime_set {
 }
 
 # @doc cmd_datetime_show
-# Show system uptime
+# Show system time
 #   -c, --compact   Show last boot time in compact format
 #   -u, --utc       Show last boot time in UTC timezone
 function cmd_datetime_show {


### PR DESCRIPTION
Make `bmc info version` without arguments
show all firmware versions like it did before.
That was broken since f2ff3222ada5f627a322e920e616c978

End-user-impact: `bmc info version` w/o arguments now
                shows all FW versions again;
                `bmc datetime show` command now has correct help;
                Fixed a typo in help message of `bmc syslog reset` command
Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>