### PR TITLE
Fix error handling in local variable assignments

### DIFF
--- a/clicmd
+++ b/clicmd
@@ -84,7 +84,8 @@ function subcommand {
     print_help "${parent}" | head -n 1
     local cmd
     for cmd in ${children[*]}; do
-      local help=$(print_help "${cmd}" | head -n 1)
+      local help
+      help=$(print_help "${cmd}" | head -n 1)
       [[ -n "${help}" ]] && printf "%-16s %s\n" "${cmd#${parent}_}" "${help}"
     done
     return

--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -56,8 +56,10 @@ function cmd_info_uptime {
     shift
   done
 
-  local sec="$(awk -F. '{print $1}' /proc/uptime)"
-  local up="$(($(date +%s) - sec))"
+  local sec
+  local up
+  sec="$(awk -F. '{print $1}' /proc/uptime)"
+  up="$(($(date +%s) - sec))"
 
   printf 'Uptime is %dd %dh %dm %ds.\n' $((sec / 86400)) \
                                         $((sec % 86400 / 3600)) \
@@ -106,10 +108,11 @@ function cmd_datetime {
 # Change time synchronization method
 #  {manual|ntp}
 function cmd_datetime_method {
-  local method="$(busctl get-property ${SETTINGS_SERVICE} \
-                                      ${TIMESYNC_METHOD_PATH} \
-                                      ${TIMESYNC_METHOD_IFACE} \
-                                      ${TIMESYNC_METHOD_PROPERTY})"
+  local method
+  method="$(busctl get-property ${SETTINGS_SERVICE} \
+                                ${TIMESYNC_METHOD_PATH} \
+                                ${TIMESYNC_METHOD_IFACE} \
+                                ${TIMESYNC_METHOD_PROPERTY})"
   method=${method##*.}
   method=${method%\"*}
 
@@ -216,17 +219,19 @@ function cmd_syslog {
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
-    local addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                      ${SYSLOG_CONFIG_PATH} \
-                                      ${NETWORK_CLIENT_IFACE} Address \
-                  2>/dev/null)"
+    local addr
+    addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                                ${SYSLOG_CONFIG_PATH} \
+                                ${NETWORK_CLIENT_IFACE} Address \
+                                2>/dev/null)"
     addr=${addr#*\"}
     addr=${addr%\"*}
 
-    local port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                      ${SYSLOG_CONFIG_PATH} \
-                                      ${NETWORK_CLIENT_IFACE} Port \
-                  2>/dev/null)"
+    local port
+    port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                                ${SYSLOG_CONFIG_PATH} \
+                                ${NETWORK_CLIENT_IFACE} Port \
+                                2>/dev/null)"
     port=${port#* }
 
     echo -n "Remote syslog server: "

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -56,8 +56,10 @@ function cmd_info_uptime {
     shift
   done
 
-  local sec="$(awk -F. '{print $1}' /proc/uptime)"
-  local up="$(($(date +%s) - sec))"
+  local sec
+  local up
+  sec="$(awk -F. '{print $1}' /proc/uptime)"
+  up="$(($(date +%s) - sec))"
 
   printf 'Uptime is %dd %dh %dm %ds.\n' $((sec / 86400)) \
                                         $((sec % 86400 / 3600)) \
@@ -106,10 +108,11 @@ function cmd_datetime {
 # Change time synchronization method
 #  {manual|ntp}
 function cmd_datetime_method {
-  local method="$(busctl get-property ${SETTINGS_SERVICE} \
-                                      ${TIMESYNC_METHOD_PATH} \
-                                      ${TIMESYNC_METHOD_IFACE} \
-                                      ${TIMESYNC_METHOD_PROPERTY})"
+  local method
+  method="$(busctl get-property ${SETTINGS_SERVICE} \
+                                ${TIMESYNC_METHOD_PATH} \
+                                ${TIMESYNC_METHOD_IFACE} \
+                                ${TIMESYNC_METHOD_PROPERTY})"
   method=${method##*.}
   method=${method%\"*}
 
@@ -219,17 +222,19 @@ function cmd_syslog {
 # @doc cmd_syslog_show
 # Show actual remote syslog server
 function cmd_syslog_show {
-    local addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                      ${SYSLOG_CONFIG_PATH} \
-                                      ${NETWORK_CLIENT_IFACE} Address \
-                  2>/dev/null)"
+    local addr
+    addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                                ${SYSLOG_CONFIG_PATH} \
+                                ${NETWORK_CLIENT_IFACE} Address \
+                                2>/dev/null)"
     addr=${addr#*\"}
     addr=${addr%\"*}
 
-    local port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                      ${SYSLOG_CONFIG_PATH} \
-                                      ${NETWORK_CLIENT_IFACE} Port \
-                  2>/dev/null)"
+    local port
+    port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                                ${SYSLOG_CONFIG_PATH} \
+                                ${NETWORK_CLIENT_IFACE} Port \
+                                2>/dev/null)"
     port=${port#* }
 
     echo -n "Remote syslog server: "

--- a/commands/diagnostics.nicole
+++ b/commands/diagnostics.nicole
@@ -25,9 +25,10 @@ function cmd_led {
 # Check the identification LED status
 function cmd_led_status {
   expect_noarg "$@"
-  local state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
-                                     ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
-                                     | awk '{print $NF}')"
+  local state
+  state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
+                               ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
+                               | awk '{print $NF}')"
   case "${state}" in
     true) state="ON";;
     false) state="OFF";;
@@ -125,7 +126,8 @@ function supportbundle_dbus {
   # remove previous reports
   busctl call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Collection.DeleteAll DeleteAll
   # create new report
-  local entry="$(busctl --list call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Dump.Create CreateDump)"
+  local entry
+  entry="$(busctl --list call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Dump.Create CreateDump)"
   if [[ -z "${entry}" ]]; then
     return 1
   fi
@@ -134,9 +136,10 @@ function supportbundle_dbus {
   # wait for report complete
   mapper wait ${mgr_obj}/entry/${entry}
   # get timestamp to construct file name
-  local elapsed="$(busctl --list get-property ${mgr_svc} \
-                          ${mgr_obj}/entry/${entry} \
-                          xyz.openbmc_project.Time.EpochTime Elapsed)"
+  local elapsed
+  elapsed="$(busctl --list get-property ${mgr_svc} \
+                    ${mgr_obj}/entry/${entry} \
+                    xyz.openbmc_project.Time.EpochTime Elapsed)"
   if [[ -z "${elapsed}" ]]; then
     return 1
   fi

--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -25,9 +25,10 @@ function cmd_led {
 # Check the identification LED status
 function cmd_led_status {
   expect_noarg "$@"
-  local state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
-                                     ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
-                                     | awk '{print $NF}')"
+  local state
+  state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
+                               ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
+                               | awk '{print $NF}')"
   case "${state}" in
     true) state="ON";;
     false) state="OFF";;

--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -75,7 +75,8 @@ function cmd_logs_export {
   local path="/run/dreport"
   local prefix="obmcdump_"
   local ext=".tar.xz"
-  local timestamp="$(date +%Y%m%d%H%M%S)"
+  local timestamp
+  timestamp="$(date +%Y%m%d%H%M%S)"
 
   mkdir -p ${path}
   chmod 0777 ${path}

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -77,7 +77,8 @@ function cmd_logs_export {
   local path="/run/dreport"
   local prefix="obmcdump_"
   local ext=".tar.xz"
-  local timestamp="$(date +%Y%m%d%H%M%S)"
+  local timestamp
+  timestamp="$(date +%Y%m%d%H%M%S)"
 
   mkdir -p ${path}
   chmod 0777 ${path}

--- a/commands/user
+++ b/commands/user
@@ -65,7 +65,9 @@ function cmd_create {
     return 1
   fi
 
-  local priv="$(role_to_group "${role}")"
+  local priv
+  priv="$(role_to_group \"${role}\")"
+ 
   busctl call ${DBUS_SERVICE} ${DBUS_ROOT_PATH} \
               ${DBUS_SERVICE} CreateUser sassb \
               "${name}" \
@@ -84,15 +86,17 @@ function cmd_show {
   while [[ $# -gt 0 ]]; do
     local user="$1"
     shift
-    local grp="$(busctl get-property ${DBUS_SERVICE} "${DBUS_ROOT_PATH}/${user}" \
-                                     ${DBUS_ATTRIBUTES} "UserPrivilege" \
-                                     2>/dev/null \
-                                     | awk '{gsub(/"/, "", $NF); print $NF}')"
+    local grp
+    grp="$(busctl get-property ${DBUS_SERVICE} "${DBUS_ROOT_PATH}/${user}" \
+                               ${DBUS_ATTRIBUTES} "UserPrivilege" \
+                               2>/dev/null \
+           | awk '{gsub(/"/, "", $NF); print $NF}')"
     if [[ -z "${grp}" ]]; then
       echo "Invalid user: ${user}" >&2
       return 1
     fi
-    local role="$(group_to_role ${grp})"
+    local role
+    role="$(group_to_role ${grp})"
     echo "${user}: ${role}"
   done
 }

--- a/profile.in
+++ b/profile.in
@@ -38,8 +38,11 @@ function help {
 # callback function for bash autocomplete
 function _cli_completion {
   local cmd="${COMP_WORDS[0]}"
-  local subcmd="$(echo "${COMP_WORDS[*]:1}" | sed 's/\w\+$//')"
-  local words="$(${cmd} autocomplete ${subcmd})"
+  local subcmd
+  local words
+  subcmd="$(echo "${COMP_WORDS[*]:1}" | sed 's/\w\+$//')"
+  words="$(${cmd} autocomplete ${subcmd})"
+
   if [[ -z "${words}" ]] && [[ ${COMP_CWORD} -gt 2 ]]; then
     COMPREPLY=($(compgen -f -- ${COMP_WORDS[COMP_CWORD]}))
   else


### PR DESCRIPTION
When a variable is assigned a value printed by a function
that can fail and return a non-zero value, and a `set -e`
is in effect, it is expected that such an assignment will
fail. However since `local` is a command per se and it
doesn't fail, the whole expression is considered successful.

Thus, in order to handle errors properly in such assignments,
I here separate declaration of a `local` variable from its
definition.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>