### PR TITLE
Fix assignments from external commands

### DIFF
--- a/commands/bmc.nicole
+++ b/commands/bmc.nicole
@@ -58,8 +58,8 @@ function cmd_info_uptime {
 
   local sec
   local up
-  sec="$(awk -F. '{print $1}' /proc/uptime)"
-  up="$(($(date +%s) - sec))"
+  sec=$(awk -F. '{print $1}' /proc/uptime)
+  up=$(($(date +%s) - sec))
 
   printf 'Uptime is %dd %dh %dm %ds.\n' $((sec / 86400)) \
                                         $((sec % 86400 / 3600)) \
@@ -109,10 +109,10 @@ function cmd_datetime {
 #  {manual|ntp}
 function cmd_datetime_method {
   local method
-  method="$(busctl get-property ${SETTINGS_SERVICE} \
-                                ${TIMESYNC_METHOD_PATH} \
-                                ${TIMESYNC_METHOD_IFACE} \
-                                ${TIMESYNC_METHOD_PROPERTY})"
+  method=$(busctl get-property ${SETTINGS_SERVICE} \
+                               ${TIMESYNC_METHOD_PATH} \
+                               ${TIMESYNC_METHOD_IFACE} \
+                               ${TIMESYNC_METHOD_PROPERTY})
   method=${method##*.}
   method=${method%\"*}
 
@@ -220,18 +220,18 @@ function cmd_syslog {
 # Show actual remote syslog server
 function cmd_syslog_show {
     local addr
-    addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                ${SYSLOG_CONFIG_PATH} \
-                                ${NETWORK_CLIENT_IFACE} Address \
-                                2>/dev/null)"
+    addr=$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                               ${SYSLOG_CONFIG_PATH} \
+                               ${NETWORK_CLIENT_IFACE} Address \
+                               2>/dev/null)
     addr=${addr#*\"}
     addr=${addr%\"*}
 
     local port
-    port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                ${SYSLOG_CONFIG_PATH} \
-                                ${NETWORK_CLIENT_IFACE} Port \
-                                2>/dev/null)"
+    port=$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                               ${SYSLOG_CONFIG_PATH} \
+                               ${NETWORK_CLIENT_IFACE} Port \
+                               2>/dev/null)
     port=${port#* }
 
     echo -n "Remote syslog server: "

--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -58,8 +58,8 @@ function cmd_info_uptime {
 
   local sec
   local up
-  sec="$(awk -F. '{print $1}' /proc/uptime)"
-  up="$(($(date +%s) - sec))"
+  sec=$(awk -F. '{print $1}' /proc/uptime)
+  up=$(($(date +%s) - sec))
 
   printf 'Uptime is %dd %dh %dm %ds.\n' $((sec / 86400)) \
                                         $((sec % 86400 / 3600)) \
@@ -109,10 +109,10 @@ function cmd_datetime {
 #  {manual|ntp}
 function cmd_datetime_method {
   local method
-  method="$(busctl get-property ${SETTINGS_SERVICE} \
-                                ${TIMESYNC_METHOD_PATH} \
-                                ${TIMESYNC_METHOD_IFACE} \
-                                ${TIMESYNC_METHOD_PROPERTY})"
+  method=$(busctl get-property ${SETTINGS_SERVICE} \
+                               ${TIMESYNC_METHOD_PATH} \
+                               ${TIMESYNC_METHOD_IFACE} \
+                               ${TIMESYNC_METHOD_PROPERTY})
   method=${method##*.}
   method=${method%\"*}
 
@@ -223,18 +223,18 @@ function cmd_syslog {
 # Show actual remote syslog server
 function cmd_syslog_show {
     local addr
-    addr="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                ${SYSLOG_CONFIG_PATH} \
-                                ${NETWORK_CLIENT_IFACE} Address \
-                                2>/dev/null)"
+    addr=$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                               ${SYSLOG_CONFIG_PATH} \
+                               ${NETWORK_CLIENT_IFACE} Address \
+                               2>/dev/null)
     addr=${addr#*\"}
     addr=${addr%\"*}
 
     local port
-    port="$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
-                                ${SYSLOG_CONFIG_PATH} \
-                                ${NETWORK_CLIENT_IFACE} Port \
-                                2>/dev/null)"
+    port=$(busctl get-property ${SYSLOG_CONFIG_SERVICE} \
+                               ${SYSLOG_CONFIG_PATH} \
+                               ${NETWORK_CLIENT_IFACE} Port \
+                               2>/dev/null)
     port=${port#* }
 
     echo -n "Remote syslog server: "

--- a/commands/diagnostics.nicole
+++ b/commands/diagnostics.nicole
@@ -26,9 +26,9 @@ function cmd_led {
 function cmd_led_status {
   expect_noarg "$@"
   local state
-  state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
-                               ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
-                               | awk '{print $NF}')"
+  state=$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
+                              ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
+                              | awk '{print $NF}')
   case "${state}" in
     true) state="ON";;
     false) state="OFF";;
@@ -127,7 +127,7 @@ function supportbundle_dbus {
   busctl call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Collection.DeleteAll DeleteAll
   # create new report
   local entry
-  entry="$(busctl --list call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Dump.Create CreateDump)"
+  entry=$(busctl --list call ${mgr_svc} ${mgr_obj} xyz.openbmc_project.Dump.Create CreateDump)
   if [[ -z "${entry}" ]]; then
     return 1
   fi
@@ -137,9 +137,9 @@ function supportbundle_dbus {
   mapper wait ${mgr_obj}/entry/${entry}
   # get timestamp to construct file name
   local elapsed
-  elapsed="$(busctl --list get-property ${mgr_svc} \
-                    ${mgr_obj}/entry/${entry} \
-                    xyz.openbmc_project.Time.EpochTime Elapsed)"
+  elapsed=$(busctl --list get-property ${mgr_svc} \
+                   ${mgr_obj}/entry/${entry} \
+                   xyz.openbmc_project.Time.EpochTime Elapsed)
   if [[ -z "${elapsed}" ]]; then
     return 1
   fi

--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -26,9 +26,9 @@ function cmd_led {
 function cmd_led_status {
   expect_noarg "$@"
   local state
-  state="$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
-                               ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
-                               | awk '{print $NF}')"
+  state=$(busctl get-property ${LED_DBUS_SERVICE} ${LED_DBUS_OBJECT} \
+                              ${LED_DBUS_INTERFACE} ${LED_DBUS_PROPERTY} \
+                              | awk '{print $NF}')
   case "${state}" in
     true) state="ON";;
     false) state="OFF";;

--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -38,8 +38,8 @@ function cmd_logs_list {
     local brief=
     local name=
     for entry in /usr/share/dreport.d/pl_user.d/*; do
-        brief="$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})"
-        name="$(realpath ${entry})"
+        brief=$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})
+        name=$(realpath ${entry})
         printf "%-20s%s\n" "${name##*/}" "${brief}"
     done
 }
@@ -58,7 +58,7 @@ function cmd_logs_show {
   for link in /usr/share/dreport.d/pl_user.d/E*${name}; do
     if [[ -f "${file}" ]] && [[ "$(realpath ${link})" = "${file}" ]]; then
       DREPORT_INCLUDE="/usr/share/cli/.include" \
-      TIME_STAMP="$(date -u)" exec "${file}"
+      TIME_STAMP=$(date -u) exec "${file}"
       return 1
     fi
   done
@@ -76,7 +76,7 @@ function cmd_logs_export {
   local prefix="obmcdump_"
   local ext=".tar.xz"
   local timestamp
-  timestamp="$(date +%Y%m%d%H%M%S)"
+  timestamp=$(date +%Y%m%d%H%M%S)
 
   mkdir -p ${path}
   chmod 0777 ${path}

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -38,8 +38,8 @@ function cmd_logs_list {
     local brief=
     local name=
     for entry in /usr/share/dreport.d/pl_user.d/*; do
-        brief="$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})"
-        name="$(realpath ${entry})"
+        brief=$(awk -F: '/^#\s+@brief:/{print $2}' ${entry})
+        name=$(realpath ${entry})
         printf "%-20s%s\n" "${name##*/}" "${brief}"
     done
 }
@@ -59,7 +59,7 @@ function cmd_logs_show {
   for link in /usr/share/dreport.d/pl_user.d/E*${name}; do
     if [[ -f "${file}" ]] && [[ "$(realpath ${link})" = "${file}" ]]; then
       DREPORT_INCLUDE="/usr/share/cli/.include" \
-      TIME_STAMP="$(date -u)" exec "${file}"
+      TIME_STAMP=$(date -u) exec "${file}"
       return 1
     fi
   done
@@ -78,7 +78,7 @@ function cmd_logs_export {
   local prefix="obmcdump_"
   local ext=".tar.xz"
   local timestamp
-  timestamp="$(date +%Y%m%d%H%M%S)"
+  timestamp=$(date +%Y%m%d%H%M%S)
 
   mkdir -p ${path}
   chmod 0777 ${path}

--- a/commands/user
+++ b/commands/user
@@ -66,7 +66,7 @@ function cmd_create {
   fi
 
   local priv
-  priv="$(role_to_group \"${role}\")"
+  priv=$(role_to_group "${role}")
  
   busctl call ${DBUS_SERVICE} ${DBUS_ROOT_PATH} \
               ${DBUS_SERVICE} CreateUser sassb \
@@ -87,16 +87,16 @@ function cmd_show {
     local user="$1"
     shift
     local grp
-    grp="$(busctl get-property ${DBUS_SERVICE} "${DBUS_ROOT_PATH}/${user}" \
+    grp=$(busctl get-property ${DBUS_SERVICE} "${DBUS_ROOT_PATH}/${user}" \
                                ${DBUS_ATTRIBUTES} "UserPrivilege" \
                                2>/dev/null \
-           | awk '{gsub(/"/, "", $NF); print $NF}')"
+          | awk '{gsub(/"/, "", $NF); print $NF}')
     if [[ -z "${grp}" ]]; then
       echo "Invalid user: ${user}" >&2
       return 1
     fi
     local role
-    role="$(group_to_role ${grp})"
+    role=$(group_to_role "${grp}")
     echo "${user}: ${role}"
   done
 }
@@ -227,7 +227,7 @@ function cmd_set_role {
   fi
 
   local priv
-  priv="$(role_to_group "${role}")"
+  priv=$(role_to_group "${role}")
 
   busctl set-property ${DBUS_SERVICE} "${DBUS_ROOT_PATH}/${name}" \
                       ${DBUS_ATTRIBUTES} "UserPrivilege" s ${priv}


### PR DESCRIPTION
Avoid using double quotes around `$(command)`
as that expression in bash already acts like quotes
in assignments and it's result is not split/tokenized

Removing the double quotes allows for using them
inside the called command without extra escaping,
and solves, for instance, the problem with wrong
invocation of `group_to_role` and `role_to_group`

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>