### PR TITLE
health: logs: fix error on show hostlogger

### DIFF
--- a/commands/health.nicole
+++ b/commands/health.nicole
@@ -59,7 +59,7 @@ function cmd_logs_show {
     if [[ -f "${file}" ]] && [[ "$(realpath "${link}")" = "${file}" ]]; then
       # Should exec fail, the script will abort due to `set -e` in effect
       DREPORT_INCLUDE="/usr/share/cli/.include" \
-      TIME_STAMP=$(date -u) exec "${file}"
+      TIME_STAMP="date -u" exec "${file}"
     fi
   done
 

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -60,7 +60,7 @@ function cmd_logs_show {
     if [[ -f "${file}" ]] && [[ "$(realpath "${link}")" = "${file}" ]]; then
       # Should exec fail, the script will abort due to `set -e` in effect
       DREPORT_INCLUDE="/usr/share/cli/.include" \
-      TIME_STAMP=$(date -u) exec "${file}"
+      TIME_STAMP="date -u" exec "${file}"
     fi
   done
 


### PR DESCRIPTION
The command `health logs show ...` has an incorrect TIME_STAMP definition.
It leads to the error when command tries to log its own messages.
    
For example: the command `health logs show hostlogger` fails when there are no hostlogger files.
    
This commit fixes the issue.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>