### PR TITLE
bmc ifconfig help: Fix command name display

### DIFF
--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -220,13 +220,13 @@ function cmd_datetime_show {
 # Configure NTP server connection
 function cmd_datetime_ntpconfig {
   if [[ $# -ge 1 && $1 =~ ^-*h(elp)?$ ]]; then
-    exec_tool netconfig --cli help ntp
+    exec_tool netconfig --cli-hide-cmd help ntp
     return
   fi
   if [[ $# -lt 3 ]]; then
     abort_badarg "Expected 3 or more arguments"
   fi
-  exec_tool netconfig --cli ntp "$@"
+  exec_tool netconfig --cli-hide-cmd ntp "$@"
 }
 
 # @sudo cmd_ifconfig admin


### PR DESCRIPTION
Previously the command name was not shown in `bmc ifconfig help <cmd>`.
That is fixed now.

Requires YADRO-KNS/obmc-yadro-netconfig#13

End-user-impact: Subcommand help for `bmc ifconfig` now properly
                 displays the command name.
Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>