### PR TITLE
clicmd: Fix autocomplete for path arguments

### DIFF
--- a/clicmd
+++ b/clicmd
@@ -189,6 +189,8 @@ function print_help {
 function autocomplete {
   local parent="cmd"
   while [[ $# -gt 0 ]]; do
+    # Only alphanumeric subcommands are possible
+    [[ $1 =~ ^[[:alnum:]]+$ ]] || break 
     parent+="_$1"
     shift
   done


### PR DESCRIPTION
Bash autocompletion would fail on path arguments like `./something`
because the code would try to treat them as subcommands.

Now only alphanumeric subcommands are treated as such.

End-user-impact: Bash autocompletion doesn't fail anymore
                 on path arguments
Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>