### PR TITLE
host: virtual-media: Support the HTTP protocol.

### DIFF
--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -192,14 +192,14 @@ function cmd_virtualmedia_status {
 # @restrict cmd_virtualmedia_mount admin
 # @doc cmd_virtualmedia_mount
 # Mount a virtual media
-#   --usb      - The USB interface type
-#   --usb-ro   - The USB interface type (read-only)
-#   --hdd      - The HDD interface type
-#   --cdrom    - The CD/DVD/BD-ROM interface type (read-only), based on file size
-#   FILE       - Path to image file. Supported the SMB and the HTTP(S) protocols.
-#  -r          - Readonly mode
-#  -u username - Username credential to connect SMB or HTTP(S) remote server.
-#  -p          - Request to input the password credential to connect SMB or HTTP(S) remote server.
+#   --usb       - The USB interface type
+#   --usb-ro    - The USB interface type (read-only)
+#   --hdd       - The HDD interface type
+#   --cdrom     - The CD/DVD/BD-ROM interface type (read-only), based on file size
+#   FILE        - Path to image file. Supported the SMB and the HTTP(S) protocols.
+#   -r          - Readonly mode
+#   -u USER     - Username credential to connect SMB or HTTP(S) remote server.
+#   -p          - Request to input the password credential to connect SMB or HTTP(S) remote server.
 function cmd_virtualmedia_mount {
   local imagefile=""
   local type=0

--- a/commands/host.vegman
+++ b/commands/host.vegman
@@ -196,17 +196,17 @@ function cmd_virtualmedia_status {
 #   --usb-ro   - The USB interface type (read-only)
 #   --hdd      - The HDD interface type
 #   --cdrom    - The CD/DVD/BD-ROM interface type (read-only), based on file size
-#   FILE       - Path to image file. Supported the SMB and the HTTPS protocols.
+#   FILE       - Path to image file. Supported the SMB and the HTTP(S) protocols.
 #  -r          - Readonly mode
-#  -u username - Username credential to connect SMB or HTTPS remote server.
-#  -p          - Request to input the password credential to connect SMB or HTTPS remote server.
+#  -u username - Username credential to connect SMB or HTTP(S) remote server.
+#  -p          - Request to input the password credential to connect SMB or HTTP(S) remote server.
 function cmd_virtualmedia_mount {
   local imagefile=""
   local type=0
   local readonly=false
   local username=""
   local password=""
-  local imagefile_pattern="^(https|smb)"
+  local imagefile_pattern="^(https?|smb)://"
   local cred_pipe=0
   while [[ $# -gt 0 ]]; do
     case "${1}" in


### PR DESCRIPTION
This patch brings support of HTTP protocol for mount VM-image from
external server.

End-user-impact: Now, the `host virtualmedia mount` command supports the
                 HTTP protocol to mount Virtual Media images from an
                 external server via HTTP.

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>