### PR TITLE
bmc:info:version: Fix display firmware versions

### DIFF
--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -78,8 +78,8 @@ function cmd_info_version {
   # If no options are given, show everything
   [[ $# -eq 0 ]] && set -- -b -u
 
-  local bmc_match='^BMC '
-  local host_match='^Host '
+  local bmc_match='^BMC .*bmc_active\]$'
+  local host_match='^Host .*bios_active\]$'
   local no_match='no-match-pattern'
   local bmc=${no_match}
   local host=${no_match}
@@ -93,7 +93,9 @@ function cmd_info_version {
     shift
   done
 
-  exec_tool fwupdate --version | grep -E "(${bmc}|${host})"
+  exec_tool fwupdate --version | \
+    awk -v re="(${bmc}|${host})" \
+      '$0 ~ re { printf "%-8s %s\n", $1, $2 }'
 }
 
 # @doc cmd_datetime


### PR DESCRIPTION
The fwupdate might represent firmware versions additionally from the
functional association.
Added a rule to match version firmware only to bmc_active and
bios_active ID for printed by fwupdate version info.

Sample:
```
vegman-s220-DARTAGNAN:~$ bmc info version
Host    N/A   [ID=bios_active]
BMC     v1.3re8e1eep5-rc5-unofficial   [ID=bmc_active]
```

End-user-impact: Now, the `bmc info version` command displays only
                 'bmc_active' and 'bios_active' IDs of firmware versions

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>