### PR TITLE
Fix logs cleanup

### DIFF
--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -118,5 +118,14 @@ function cmd_logs_clear {
     rm -f "${logfile}".*
   done
 
+  # Remove journals from previous BMC installations
+  local machine_id
+  machine_id=$(cat /etc/machine-id)
+  for d in /var/log/journal/*; do
+      if [ -d "${d}" ] && [ "${d##*/}" != "${machine_id}" ]; then
+          rm -fr "${d}"
+      fi
+  done
+
   echo "All logs are cleared."
 }

--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -114,6 +114,8 @@ function cmd_logs_clear {
   )
   for logfile in "${truncating[@]}"; do
     :> "${logfile}"
+    # Remove rotated logs
+    rm -f "${logfile}".*
   done
 
   echo "All logs are cleared."


### PR DESCRIPTION
- vegman: health: logs: clean: remove rotated logs
    
    On VEGMAN some logs are rotated by `logrotate` service.
    These files also should be removed during `health logs clean` command.

- vegman: heath: logs: clean: remove obsolete logs
    
    SD-card on VEGMAN accumulates journals during BMC resetting and fullchip
    flashing that no longer used and not counted during the rotation.
    
    These journals also should be removed by `health logs clean` command.
