### PR TITLE
vegman: inventory: use lsinventory

### DIFF
--- a/commands/health.vegman
+++ b/commands/health.vegman
@@ -13,7 +13,7 @@
 # @doc cmd_inventory
 # System inventory
 function cmd_inventory {
-  ipmitool fru
+  exec_tool lsinventory "$@"
 }
 
 # @sudo cmd_sensors admin,operator,user


### PR DESCRIPTION
This commit changes `health inventory` command on VEGMAN.
Now it will call `lsinventory` instead of `ipmitool fru`.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>