### PR TITLE
diagnostics.vegman: Fix unbound variable

### DIFF
--- a/commands/diagnostics.vegman
+++ b/commands/diagnostics.vegman
@@ -214,7 +214,7 @@ function cmd_intrusion_clear {
   # We do want word splitting here, in fact `set --` is
   # specifically designed for word splitting.
   # shellcheck disable=SC2046
-  set -- $(gpiofind ${INTR_RST_GPIO_PIN})
+  set -- $(gpiofind ${INTR_RST_GPIO_PIN}) "" ""
   chip=$1
   pin=$2
 


### PR DESCRIPTION
If there is no GPIO line for intrusion detection reset,
the `diagnostics intrusion clear` command would fail
with an `Unbound variable` error.

Add empty arguments to `set` to be used as `$1` and `$2`
in that case.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>