### PR TITLE
clicmd: change the command name in the help info

### DIFF
--- a/clicmd
+++ b/clicmd
@@ -78,7 +78,8 @@ fi
 # by the name of the CLI command that called this function
 function exec_tool {
   local FNAME="${FUNCNAME[1]##cmd_}"
-  local PNAME="bmc ${FNAME//_/ }"
+  local PNAME
+  PNAME="$(basename "${USER_CMD}") ${FNAME//_/ }"
   local TOOL="$1"; shift
   exec -a "${PNAME}" "${TOOL}" "$@"
 }


### PR DESCRIPTION
Change the command name, displayed in the help
usage info section from 'bmc' to 'health'.

End-user-impact: Change the command name in the help usage info.

Signed-off-by: Kirill Pakhomov <k.pakhomov@yadro.com>