### PR TITLE
clicmd: fixed invalid regular expression when creating a new user

### DIFF
--- a/commands/user
+++ b/commands/user
@@ -19,7 +19,7 @@ DBUS_ROOT_PATH="/xyz/openbmc_project/user"
 DBUS_ATTRIBUTES="xyz.openbmc_project.User.Attributes"
 DBUS_DELETE="xyz.openbmc_project.Object.Delete"
 
-USERNAME_REGEX="^[\.a-zA-Z0-9_-]+$"
+USERNAME_REGEX="^[a-zA-Z_][a-zA-Z0-9_]*$"
 
 # This one us used in help, need to output a single word of role
 # and nothing else. Please do not 'beautify'.


### PR DESCRIPTION
Requirements:
  - Cannot start with a number
  - No special characters except underscore
These requirements are necessary due to the need for consistency with the WebUI

End-user-impact: fixed invalid regular expression when creating a new user
Signed-off-by: Evgeniy Kislenok <e.kislenok@yadro.com>