### PR TITLE
bmc: vegman: add command for service management

### DIFF
--- a/commands/bmc.vegman
+++ b/commands/bmc.vegman
@@ -195,6 +195,14 @@ function cmd_syslog {
   exec_tool netconfig --cli "$@"
 }
 
+# @sudo cmd_services admin
+# @restrict cmd_services admin
+# @doc cmd_services
+# Manage BMC services
+function cmd_services {
+  exec_tool srvctl "$@"
+}
+
 # @restrict cmd_config admin
 # @doc cmd_config
 # BMC config backup and restore


### PR DESCRIPTION
This adds `bmc services` command for services management running on BMC.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>